### PR TITLE
feat: always-on mic with speak/type mode for guess-the-drawing

### DIFF
--- a/games/guess-the-drawing/css/styles.css
+++ b/games/guess-the-drawing/css/styles.css
@@ -444,6 +444,55 @@ body {
     }
 }
 
+/* Mode Selector */
+.mode-selector {
+    text-align: center;
+    font-size: 1.1rem;
+    color: var(--pencil-gray);
+    width: 100%;
+}
+
+.mode-selector > p {
+    margin-bottom: 12px;
+}
+
+.mode-options {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+
+.mode-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border: 3px solid var(--sketch-line);
+    border-radius: 12px;
+    background: white;
+    cursor: pointer;
+    font-family: 'Patrick Hand', cursive;
+    font-size: 1.2rem;
+    transition: all 0.2s;
+    box-shadow: 3px 3px 0 var(--sketch-line);
+}
+
+.mode-option:hover {
+    transform: translate(1px, 1px);
+    box-shadow: 2px 2px 0 var(--sketch-line);
+}
+
+.mode-option:has(input:checked) {
+    background: var(--pencil-gray);
+    color: white;
+    transform: translate(3px, 3px);
+    box-shadow: none;
+}
+
+.mode-option input[type="radio"] {
+    display: none;
+}
+
 /* Animations for screen transitions */
 @keyframes fadeIn {
     from { opacity: 0; transform: translateY(10px); }

--- a/games/guess-the-drawing/index.html
+++ b/games/guess-the-drawing/index.html
@@ -16,8 +16,20 @@
             <h1 class="title">Guess the Drawing</h1>
             <div class="instructions">
                 <p>A pencil will draw a picture.</p>
-                <p>Say what you see into the microphone!</p>
-                <p>You have 30 seconds to guess.</p>
+                <p>Guess what it is in 30 seconds!</p>
+            </div>
+            <div class="mode-selector">
+                <p>How do you want to answer?</p>
+                <div class="mode-options">
+                    <label class="mode-option">
+                        <input type="radio" name="input-mode" id="mode-speak" value="speak" checked>
+                        <span>🎤 Say it</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="input-mode" id="mode-type" value="type">
+                        <span>⌨️ Type it</span>
+                    </label>
+                </div>
             </div>
             <div class="scoring-info">
                 <p><span class="star-icon">&#9733;</span> +1 star for correct guess</p>

--- a/games/guess-the-drawing/js/game.js
+++ b/games/guess-the-drawing/js/game.js
@@ -15,6 +15,7 @@ const Game = {
 
     usedDrawings: [],
     isMicActive: false,
+    inputMode: 'speak', // 'speak' or 'type' - set from main.js before start()
 
     init() {
         this.reset();
@@ -87,9 +88,23 @@ const Game = {
         UI.hideFeedback();
         UI.updateRound(this.data.currentRound);
         UI.resetTimer();
-        UI.clearGuessDisplay();
+        UI.clearGuessDisplay(this.inputMode);
         UI.setMicActive(false);
         this.isMicActive = false;
+
+        // Auto-start input based on mode
+        if (this.inputMode === 'speak') {
+            Audio.resume();
+            const started = Speech.startListening();
+            if (started) {
+                UI.setMicActive(true);
+                this.isMicActive = true;
+            } else {
+                UI.showTextFallback();
+            }
+        } else {
+            UI.showTypingInput();
+        }
 
         // Start drawing animation
         Drawing.startDrawing(this.data.currentDrawing, () => {
@@ -115,23 +130,7 @@ const Game = {
 
     toggleMic() {
         if (this.state !== 'PLAYING') return;
-
-        if (this.isMicActive) {
-            Speech.stopListening();
-            UI.setMicActive(false);
-            this.isMicActive = false;
-        } else {
-            Audio.resume(); // Ensure audio context is ready
-            const started = Speech.startListening();
-            if (started) {
-                UI.setMicActive(true);
-                this.isMicActive = true;
-                UI.updateGuessDisplay('Listening...');
-            } else {
-                // Speech not supported, show text fallback
-                UI.showTextFallback();
-            }
-        }
+        if (this.inputMode === 'speak') return; // mic is always on in speak mode
     },
 
     checkGuess(spokenText) {
@@ -160,6 +159,7 @@ const Game = {
         Drawing.stopDrawing();
         UI.setMicActive(false);
         this.isMicActive = false;
+        if (this.inputMode === 'type') UI.hideTypingInput();
 
         // Update score
         this.data.stars += 1;
@@ -185,6 +185,7 @@ const Game = {
         Drawing.stopDrawing();
         UI.setMicActive(false);
         this.isMicActive = false;
+        if (this.inputMode === 'type') UI.hideTypingInput();
 
         // Update score (minimum 0 stars)
         this.data.stars = Math.max(0, this.data.stars - 2);

--- a/games/guess-the-drawing/js/main.js
+++ b/games/guess-the-drawing/js/main.js
@@ -1,6 +1,13 @@
 // Main Entry Point
 // Initializes all modules and sets up the application
 
+const INPUT_MODE_KEY = 'guess-the-drawing-input-mode';
+
+function getSelectedMode() {
+    const checked = document.querySelector('input[name="input-mode"]:checked');
+    return checked ? checked.value : 'speak';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize UI first
     UI.init();
@@ -22,8 +29,21 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize game logic
     Game.init();
 
+    // Load saved input mode preference from localStorage
+    const savedMode = localStorage.getItem(INPUT_MODE_KEY) || 'speak';
+    const modeInputs = document.querySelectorAll('input[name="input-mode"]');
+    modeInputs.forEach(input => {
+        input.checked = input.value === savedMode;
+        input.addEventListener('change', () => {
+            if (input.checked) {
+                localStorage.setItem(INPUT_MODE_KEY, input.value);
+            }
+        });
+    });
+
     // Set up button handlers
     UI.onStartClick(() => {
+        Game.inputMode = getSelectedMode();
         Game.start();
     });
 

--- a/games/guess-the-drawing/js/ui.js
+++ b/games/guess-the-drawing/js/ui.js
@@ -116,8 +116,12 @@ const UI = {
         }
     },
 
-    clearGuessDisplay() {
-        this.elements.guessDisplay.textContent = 'Press the microphone and say what you see...';
+    clearGuessDisplay(inputMode = 'speak') {
+        if (inputMode === 'type') {
+            this.elements.guessDisplay.textContent = 'Type your guess below';
+        } else {
+            this.elements.guessDisplay.textContent = 'Listening...';
+        }
         this.elements.guessDisplay.classList.remove('has-text');
     },
 
@@ -130,6 +134,20 @@ const UI = {
     hideTextFallback() {
         this.elements.textFallback.classList.add('hidden');
         this.elements.textFallback.value = '';
+    },
+
+    // Intentional typing mode (user chose to type)
+    showTypingInput() {
+        this.elements.textFallback.classList.remove('hidden');
+        this.elements.textFallback.value = '';
+        this.elements.micBtn.style.display = 'none';
+        this.elements.textFallback.focus();
+    },
+
+    hideTypingInput() {
+        this.elements.textFallback.classList.add('hidden');
+        this.elements.textFallback.value = '';
+        this.elements.micBtn.style.display = '';
     },
 
     // Feedback overlays


### PR DESCRIPTION
Implements #issue-4

- Mic is now always enabled at the start of each round in speak mode (no manual activation needed)
- Adds a speak/type mode selector on the start screen
- Saves the user's preference in localStorage (key: `guess-the-drawing-input-mode`)

Closes #4

Generated with [Claude Code](https://claude.ai/code)