### PR TITLE
fix: slow down drawing animation and fix answer acceptance

### DIFF
--- a/games/guess-the-drawing/js/drawing.js
+++ b/games/guess-the-drawing/js/drawing.js
@@ -173,20 +173,27 @@ const Drawing = {
         let index = 0;
         let lastPoint = null;
 
-        // Calculate speed to complete drawing in ~15 seconds at 60fps
-        // Total frames = 15 * 60 = 900
-        const totalFrames = 900;
-        const pointsPerFrame = Math.max(1, Math.ceil(points.length / totalFrames));
+        // Time-based animation: complete drawing in ~20 seconds regardless of point count
+        const targetDuration = 20000; // ms
+        const startTime = performance.now();
 
-        const animate = () => {
+        const animate = (timestamp) => {
             if (!this.isDrawing) return;
 
-            // Draw multiple points per frame for speed
-            for (let i = 0; i < pointsPerFrame && index < points.length; i++, index++) {
+            // Determine how far along we should be based on elapsed time
+            const elapsed = timestamp - startTime;
+            const progress = Math.min(elapsed / targetDuration, 1);
+            const targetIndex = Math.floor(progress * points.length);
+
+            let lastNonLiftPoint = null;
+
+            // Draw all points up to targetIndex
+            while (index <= targetIndex && index < points.length) {
                 const point = points[index];
+                index++;
 
                 if (point.lift) {
-                    lastPoint = null;
+                    lastPoint = point;
                     continue;
                 }
 
@@ -208,11 +215,12 @@ const Drawing = {
                 point.scaledX = scaledX;
                 point.scaledY = scaledY;
                 lastPoint = point;
+                lastNonLiftPoint = point;
+            }
 
-                // Update pencil position on last point of this batch
-                if (i === pointsPerFrame - 1 || index === points.length - 1) {
-                    this.updatePencil(point, lastPoint);
-                }
+            // Update pencil to last drawn position
+            if (lastNonLiftPoint) {
+                this.updatePencil(lastNonLiftPoint, lastNonLiftPoint);
             }
 
             if (index < points.length && this.isDrawing) {

--- a/games/guess-the-drawing/js/speech.js
+++ b/games/guess-the-drawing/js/speech.js
@@ -59,23 +59,32 @@ const Speech = {
         let finalTranscript = '';
 
         for (let i = event.resultIndex; i < event.results.length; i++) {
-            const transcript = event.results[i][0].transcript;
-
             if (event.results[i].isFinal) {
-                finalTranscript += transcript;
+                finalTranscript += event.results[i][0].transcript;
             } else {
-                interimTranscript += transcript;
+                interimTranscript += event.results[i][0].transcript;
             }
         }
 
-        // Update interim display
+        // Update display with top alternative
         if (this.onInterimCallback && (interimTranscript || finalTranscript)) {
             this.onInterimCallback(interimTranscript || finalTranscript);
         }
 
-        // Check final result
-        if (finalTranscript && this.onResultCallback) {
-            this.onResultCallback(finalTranscript);
+        // Check all alternatives for final results (not just the top one)
+        if (this.onResultCallback) {
+            for (let i = event.resultIndex; i < event.results.length; i++) {
+                if (event.results[i].isFinal) {
+                    for (let j = 0; j < event.results[i].length; j++) {
+                        this.onResultCallback(event.results[i][j].transcript);
+                    }
+                }
+            }
+        }
+
+        // Also check interim transcripts to catch answers before a session restart
+        if (interimTranscript && this.onResultCallback) {
+            this.onResultCallback(interimTranscript);
         }
     },
 

--- a/games/guess-the-drawing/js/ui.js
+++ b/games/guess-the-drawing/js/ui.js
@@ -196,7 +196,7 @@ const UI = {
     },
 
     onTextInput(callback) {
-        this.elements.textFallback.addEventListener('keypress', (e) => {
+        this.elements.textFallback.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
                 callback(e.target.value);
                 e.target.value = '';


### PR DESCRIPTION
Fixes two bugs in the guess-the-drawing game:

- Drawing animated too fast: switched to time-based animation targeting 20s completion, regardless of how many interpolated points a drawing has
- Answers not accepted: fixed speech recognition to check all alternatives (not just top result) and interim transcripts; also fixed deprecated keypress -> keydown for text input

Closes #22

Generated with [Claude Code](https://claude.ai/code)