### PR TITLE
Add 5 new songs to K-Pop Rhythm Tap

### DIFF
--- a/games/kpop-rythm-tap/src/beatmap.js
+++ b/games/kpop-rythm-tap/src/beatmap.js
@@ -30,13 +30,56 @@ function percentile(arr, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
+// Generate a playable BPM-based beatmap when no analyzed data is available.
+// Notes are placed on the beat grid with lane assignments via seeded RNG.
+function generateProceduralBeatmap(song, difficulty) {
+  const bpm = song.bpm || 120;
+  const offset = song.offset || 0.5;
+  const rng = mulberry32(hashString(song.id + difficulty));
+  const beat = 60.0 / bpm;
+  const maxDuration = 240; // generate up to 4 min; game stops at actual audio end
+
+  // Subdivision: easy = quarter notes, medium = 8th notes, hard = 8th + 16th
+  const subdivisions = difficulty === 'easy' ? [0] : difficulty === 'hard' ? [0, 0.5, 0.75] : [0, 0.5];
+
+  const notes = [];
+  let lastLane = -1;
+  let sameLaneCount = 0;
+
+  for (let t = offset; t < maxDuration; t = Math.round((t + beat) * 10000) / 10000) {
+    for (const sub of subdivisions) {
+      const noteTime = Math.round((t + sub * beat) * 10000) / 10000;
+      if (noteTime >= maxDuration) break;
+      // On easy, only place notes on beat (sub=0)
+      // On medium/hard, occasionally skip off-beats
+      if (sub !== 0 && rng() < 0.35) continue;
+
+      let lane = Math.floor(rng() * 4);
+      if (lane === lastLane && sameLaneCount >= 2) {
+        let attempts = 0;
+        while (lane === lastLane && attempts < 10) {
+          lane = Math.floor(rng() * 4);
+          attempts++;
+        }
+      }
+      if (lane === lastLane) sameLaneCount++;
+      else sameLaneCount = 1;
+      lastLane = lane;
+
+      notes.push({ time: noteTime, lane, hit: false, judged: false });
+    }
+  }
+
+  return notes;
+}
+
 export function generateBeatmap(song, difficulty = 'medium') {
   const { id } = song;
   const data = beatmaps[id];
 
   if (!data) {
-    // Fallback: no beatmap data available
-    return [];
+    // Fallback: generate procedural BPM-based notes until analyze-songs.py is run
+    return generateProceduralBeatmap(song, difficulty);
   }
 
   const events = data.events;

--- a/games/kpop-rythm-tap/src/songs.js
+++ b/games/kpop-rythm-tap/src/songs.js
@@ -9,4 +9,9 @@ export const songs = [
   { id: 'takedown', title: 'Takedown', file: 'songs/takedown.mp3', bpm: 136.0, offset: 0.998, stars: 4 },
   { id: 'how-its-done', title: "How It's Done", file: 'songs/how-its-done.mp3', bpm: 161.5, offset: 0.093, stars: 4 },
   { id: 'path', title: 'Path', file: 'songs/path.mp3', bpm: 172.3, offset: 0.279, stars: 5 },
+  { id: 'best-day', title: 'Best Day of My Life', file: 'songs/best-day.mp3', bpm: 149.0, offset: 0.5, stars: 3 },
+  { id: 'zoo', title: 'Zoo', file: 'songs/zoo.mp3', bpm: 105.0, offset: 0.5, stars: 2 },
+  { id: 'shake-it-off', title: 'Shake It Off', file: 'songs/shake-it-off.mp3', bpm: 160.0, offset: 0.5, stars: 3 },
+  { id: 'chicken-banana', title: 'Chicken Banana', file: 'songs/chicken-banana.mp3', bpm: 120.0, offset: 0.5, stars: 2 },
+  { id: 'better-when-im-dancing', title: "Better When I'm Dancing", file: 'songs/better-when-im-dancing.mp3', bpm: 100.0, offset: 0.5, stars: 1 },
 ];

--- a/scripts/analyze-songs.py
+++ b/scripts/analyze-songs.py
@@ -32,6 +32,11 @@ SONG_IDS = [
     'strategy',
     'love-maybe',
     'path',
+    'best-day',
+    'zoo',
+    'shake-it-off',
+    'chicken-banana',
+    'better-when-im-dancing',
 ]
 
 


### PR DESCRIPTION
Adds Best Day of My Life, Zoo, Shake It Off, Chicken Banana, and Better When I'm Dancing to the song list.

Also improves the beatmap fallback to generate playable BPM-based notes for songs without analyzed data.

**Next step:** Add MP3 files to `games/kpop-rythm-tap/public/songs/` and run `python scripts/analyze-songs.py` for synced beatmaps.

Closes #25

Generated with [Claude Code](https://claude.ai/code)