### PR TITLE
chore(ci): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,14 +8,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build-cache.json
@@ -27,7 +27,7 @@ jobs:
             build-
 
       - name: Restore game dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             games/balloon-pop-blitz/node_modules
@@ -45,7 +45,7 @@ jobs:
         run: node scripts/build-all.js
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,14 +10,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
       - name: Restore build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .build-cache.json
@@ -29,7 +29,7 @@ jobs:
             build-
 
       - name: Restore game dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             games/balloon-pop-blitz/node_modules
@@ -48,14 +48,14 @@ jobs:
 
       - name: Deploy preview to Cloudflare Pages
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=games-ross-dev --branch=${{ github.head_ref }}
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;


### PR DESCRIPTION
GitHub is force-running our Node 20 actions on Node 24 (annotation on the last deploy). This moves everything to the current majors, all of which declare `node24` natively.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/github-script` | v7 | v9 |
| `cloudflare/wrangler-action` | v3 | v4 |

`anthropics/claude-code-action@v1` is unchanged — v1 is still its current major and it wasn't in the deprecation warning.

## Breaking changes, checked against this repo

- **checkout v7** blocks fork-PR checkout on `pull_request_target` / `workflow_run`. These workflows only use `push`, `pull_request`, and issue/comment triggers.
- **setup-node v5+** auto-caches when `package.json` has a `packageManager` field. The root `package.json` has none and there's no root lockfile, so the explicit `actions/cache` steps stay in charge.
- **github-script v9** drops `require('@actions/github')` and injects `getOctokit` as a parameter. The preview-comment script uses only `github.rest.*` and `context`.
- **wrangler-action v4** defaults to Wrangler v4 instead of v3. `pages deploy` is unchanged there, and the runner is on Node 22.

## Validation

This PR's own run exercises `preview.yml` end to end — checkout v7, setup-node v7, cache v6, wrangler-action v4, and the github-script v9 comment step. Merging then exercises `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)