### PR TITLE
feat: add Air Hockey, a real-time two-player game

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ name: Deploy to Cloudflare Pages
 on:
   push:
     branches: [main]
+  # Lets the Worker be redeployed without pushing to main — useful for
+  # confirming the API token has Workers Scripts:Edit before relying on it.
+  workflow_dispatch:
 
 jobs:
   # Deployed as its own job rather than a dependency of `deploy`, so that a
@@ -18,13 +21,23 @@ jobs:
         with:
           node-version: 22
 
+      - name: Install
+        working-directory: multiplayer-server
+        run: npm ci
+
+      # `wrangler deploy` bundles with esbuild, which strips types without
+      # checking them, so a type error would otherwise ship silently. The game
+      # side is covered by its own `tsc && vite build`.
+      - name: Typecheck
+        working-directory: multiplayer-server
+        run: npm run typecheck
+
       - name: Deploy Worker + Durable Object
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: multiplayer-server
-          preCommands: npm ci
           command: deploy
 
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,28 @@ on:
     branches: [main]
 
 jobs:
+  # Deployed as its own job rather than a dependency of `deploy`, so that a
+  # multiplayer hiccup never blocks the rest of the arcade from shipping.
+  # Air Hockey falls back to solo-vs-bot if the Worker is unreachable.
+  worker:
+    name: Deploy multiplayer server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Deploy Worker + Durable Object
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: multiplayer-server
+          preCommands: npm ci
+          command: deploy
+
   deploy:
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +52,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
+            games/air-hockey/node_modules
             games/balloon-pop-blitz/node_modules
             games/guess-the-drawing/node_modules
             games/hanyverse/node_modules
@@ -43,6 +66,10 @@ jobs:
 
       - name: Build all games
         run: node scripts/build-all.js
+        env:
+          # Base URL of the multiplayer Worker. Optional: unset, the game
+          # falls back to <origin>/mp and then to solo-vs-bot.
+          VITE_MP_SERVER_URL: ${{ vars.MP_SERVER_URL }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
+            games/air-hockey/node_modules
             games/balloon-pop-blitz/node_modules
             games/guess-the-drawing/node_modules
             games/hanyverse/node_modules
@@ -45,6 +46,10 @@ jobs:
 
       - name: Build all games
         run: node scripts/build-all.js
+        env:
+          # Base URL of the multiplayer Worker. Optional: unset, the game
+          # falls back to <origin>/mp and then to solo-vs-bot.
+          VITE_MP_SERVER_URL: ${{ vars.MP_SERVER_URL }}
 
       - name: Deploy preview to Cloudflare Pages
         id: deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,6 +5,40 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  # Its own Worker (`air-hockey-server-preview`) so a preview client never
+  # joins a room on the production server — see the [env.preview] comment in
+  # multiplayer-server/wrangler.toml for why that matters.
+  #
+  # Independent of `preview` rather than a dependency of it, matching the
+  # production workflow: a multiplayer hiccup should never stop the rest of the
+  # arcade from being previewable. The URL is static, so the build does not
+  # need to wait for this job to finish.
+  worker:
+    name: Deploy preview multiplayer server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install
+        working-directory: multiplayer-server
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: multiplayer-server
+        run: npm run typecheck
+
+      - name: Deploy preview Worker + Durable Object
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: multiplayer-server
+          command: deploy --env preview
+
   preview:
     runs-on: ubuntu-latest
     permissions:
@@ -47,9 +81,10 @@ jobs:
       - name: Build all games
         run: node scripts/build-all.js
         env:
-          # Base URL of the multiplayer Worker. Optional: unset, the game
+          # The *preview* Worker, never production — so a protocol or rules.ts
+          # change under review cannot reach a live match. Unset, the game
           # falls back to <origin>/mp and then to solo-vs-bot.
-          VITE_MP_SERVER_URL: ${{ vars.MP_SERVER_URL }}
+          VITE_MP_SERVER_URL: ${{ vars.MP_PREVIEW_SERVER_URL }}
 
       - name: Deploy preview to Cloudflare Pages
         id: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,31 @@ Family Game Arcade — a monorepo of browser games built with Claude Code, deplo
 games.ross.dev/
   landing/          # Landing page (index.html, styles.css, icons/)
   games/            # Each game in its own directory
+  multiplayer-server/  # Cloudflare Worker + Durable Object for real-time multiplayer
   scripts/          # Build orchestrator
   dist/             # Build output (gitignored)
   .github/          # CI/CD workflows + Claude integration
 ```
 
+## Multiplayer
+
+`multiplayer-server/` is a Cloudflare Worker with a Durable Object per game
+room, deployed separately from the static site. It hosts the real-time matches
+for Air Hockey: 60Hz authoritative physics, 30Hz snapshots over WebSockets.
+
+The simulation lives in `games/air-hockey/src/shared/rules.ts` and is imported
+by both the Worker and the game client (the client uses it for solo-vs-bot
+play). It lives in the game directory on purpose — the build cache only hashes
+`games/<slug>/`, so rules changes must live there to invalidate it.
+
+See [`multiplayer-server/README.md`](multiplayer-server/README.md) for the
+one-time setup needed to point the game at the deployed Worker.
+
 ## Game Inventory
 
 | Slug | Display Name | Tech Stack | Build |
 |------|-------------|-----------|-------|
+| air-hockey | Air Hockey | PixiJS v8 + TS + Vite (+ Cloudflare Worker/DO) | `tsc && vite build` |
 | asteroid-dodger | Asteroid Dodger | React + Vite | `vite build` |
 | balloon-pop-blitz | Balloon Pop Blitz | React + Vite | `vite build` |
 | comet-dash | Comet Dash | Babylon.js + TS + Vite | `vite build` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ by both the Worker and the game client (the client uses it for solo-vs-bot
 play). It lives in the game directory on purpose — the build cache only hashes
 `games/<slug>/`, so rules changes must live there to invalidate it.
 
+It deploys twice: `air-hockey-server` from `main`, and
+`air-hockey-server-preview` from every PR, so a preview client never joins a
+room on the production server. Each build is pointed at the right one by the
+`MP_SERVER_URL` / `MP_PREVIEW_SERVER_URL` repository variables.
+
+The API token needs `Workers Scripts: Edit`, which is separate from the
+`Cloudflare Pages: Edit` the site uses. The Worker deploys as its own CI job,
+so if that permission is missing the site still ships green while the Worker
+quietly stops updating.
+
 See [`multiplayer-server/README.md`](multiplayer-server/README.md) for the
 one-time setup needed to point the game at the deployed Worker.
 

--- a/games/air-hockey/.gitignore
+++ b/games/air-hockey/.gitignore
@@ -1,0 +1,1 @@
+test/screenshots/

--- a/games/air-hockey/CLAUDE.md
+++ b/games/air-hockey/CLAUDE.md
@@ -1,0 +1,92 @@
+# Air Hockey
+
+Real-time two-player air hockey. Two browsers on two devices share one table
+via a Cloudflare Durable Object, or one player can take on a bot.
+
+**Stack:** PixiJS v8 + pixi-filters + TypeScript + Vite.
+**Server:** [`multiplayer-server/`](../../multiplayer-server) (Worker + Durable Object).
+
+## How a match works
+
+The server is authoritative. It runs the physics at 60Hz and broadcasts a
+snapshot 30 times a second; clients never simulate the puck during online play.
+That means the two browsers can't disagree about the score, and a tampered
+client can't cheat — paddle input is clamped to the sender's own half
+server-side.
+
+The client smooths that 30Hz feed with **buffered interpolation**: it renders
+~95ms behind the newest snapshot and interpolates between the two that straddle
+that moment. Its *own* paddle is drawn from local prediction instead
+(`advancePaddle`, the same speed limit the server applies), so your hand never
+feels laggy. Impact events are queued and fired at the moment the frame they
+belong to is actually drawn, so a goal sound never precedes the goal.
+
+Solo play is not a separate code path. `BotTransport` runs the identical
+simulation in-page and speaks the same protocol as the Durable Object, so
+`main.ts` never branches on game mode.
+
+## Files
+
+| File | Role |
+|------|------|
+| `src/shared/rules.ts` | The simulation. **Shared verbatim with the Worker.** |
+| `src/protocol.ts` | Message types + the `Transport` interface both modes implement |
+| `src/net.ts` | WebSocket transport, server discovery, health probe |
+| `src/bot.ts` | In-page transport with a bot opponent (easy/normal/hard) |
+| `src/view.ts` | All Pixi rendering |
+| `src/fx.ts` | Pooled additive particles + screen shake |
+| `src/audio.ts` | Synthesized Web Audio (no asset files) |
+| `src/ui.ts` | DOM menus, room-code entry, HUD chips |
+| `src/main.ts` | Boot, input, interpolation, frame loop |
+
+`rules.ts` lives here rather than beside the Worker on purpose: the monorepo
+build cache only hashes `games/<slug>/`, so rules changes must live in this
+directory to invalidate it.
+
+## Gotchas worth knowing
+
+- **Build every node once, then move it.** Rebuilding Pixi Graphics each frame
+  re-tessellates and re-uploads geometry; doing that dropped a software
+  renderer to 8fps. Paddles, puck, trail and flashes are built in the
+  constructor and only repositioned.
+- **`arc()` continues the current path.** Without an explicit `moveTo()` to the
+  arc's start point, Pixi draws a line to it from wherever the path was, which
+  put a stray diagonal across the table.
+- **A `TextStyle` shared between two `Text` nodes is shared state.** Recolouring
+  one recoloured both; each label needs its own style object.
+- **Don't lower the bloom filter's resolution.** The filter renders the whole
+  layer through itself, so half-res softens the crisp table lines, not just the
+  glow.
+- **The puck can get pinned.** A paddle held against a wall makes the wall clamp
+  and the paddle's outward push cancel every tick, freezing the puck (kids do
+  this in corners deliberately). `rules.ts` watches for a puck that hasn't
+  travelled and slides it back out *around* the paddle.
+- **Fixed-timestep with catch-up.** The bot transport advances by real elapsed
+  time, so a slow device drops frames instead of playing in slow motion.
+
+## Local development
+
+```bash
+# terminal 1 — the game server
+cd ../../multiplayer-server && npm install && npm run dev
+
+# terminal 2 — the game
+npm install && npm run dev
+# then open http://localhost:5173/?server=ws://localhost:8787
+```
+
+Solo-vs-bot needs no server at all.
+
+## Smoke test
+
+`test/smoke.mjs` serves the built `dist/` under a subpath and drives **two
+independent browser contexts** through a real networked match — asserting both
+browsers agree on the score and the puck, and that a disconnect is noticed.
+
+```bash
+npm i -D playwright          # not a committed dependency
+cd ../../multiplayer-server && npm run dev &
+cd ../games/air-hockey && npm run build && node test/smoke.mjs
+```
+
+It writes screenshots to `test/screenshots/` (gitignored).

--- a/games/air-hockey/index.html
+++ b/games/air-hockey/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#04060f" />
+    <title>Air Hockey</title>
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%230b1330'/%3E%3Ccircle cx='16' cy='16' r='6.5' fill='%23fff2c4' stroke='%23ffb03a' stroke-width='2'/%3E%3C/svg%3E"
+    />
+    <link rel="stylesheet" href="./src/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <!-- Floating controls, visible during play -->
+    <div id="hud" class="hidden">
+      <button id="btn-quit" class="chip" type="button" aria-label="Back to menu">‹ Menu</button>
+      <div id="conn" class="chip chip-quiet"></div>
+      <button id="btn-mute" class="chip" type="button" aria-label="Toggle sound">🔊</button>
+    </div>
+
+    <div id="overlay">
+      <!-- Main menu -->
+      <section class="screen" id="screen-menu">
+        <h1 class="title">AIR<span>HOCKEY</span></h1>
+        <p class="tagline">First to 7 goals wins</p>
+        <div class="stack">
+          <button class="btn btn-primary" id="btn-solo" type="button">
+            <span class="btn-icon">🤖</span> Play the Computer
+          </button>
+          <div class="difficulty" role="group" aria-label="Computer difficulty">
+            <button class="diff" data-diff="easy" type="button">Easy</button>
+            <button class="diff is-active" data-diff="normal" type="button">Normal</button>
+            <button class="diff" data-diff="hard" type="button">Hard</button>
+          </div>
+          <button class="btn btn-secondary" id="btn-friend" type="button">
+            <span class="btn-icon">👋</span> Play a Friend
+          </button>
+        </div>
+        <p class="hint">Move your paddle with the mouse or your finger.</p>
+      </section>
+
+      <!-- Host / join chooser -->
+      <section class="screen hidden" id="screen-friend">
+        <h2 class="heading">Play a Friend</h2>
+        <p class="tagline">Two devices, one table.</p>
+        <div class="stack">
+          <button class="btn btn-primary" id="btn-host" type="button">
+            <span class="btn-icon">✨</span> Start a New Game
+          </button>
+          <button class="btn btn-secondary" id="btn-join" type="button">
+            <span class="btn-icon">🔑</span> Join With a Code
+          </button>
+          <button class="btn btn-ghost" data-back="menu" type="button">Back</button>
+        </div>
+      </section>
+
+      <!-- Hosting: show the code -->
+      <section class="screen hidden" id="screen-host">
+        <h2 class="heading">Your Game Code</h2>
+        <div class="code" id="host-code">----</div>
+        <p class="tagline" id="host-status">Waiting for the other player…</p>
+        <div class="stack">
+          <button class="btn btn-secondary" id="btn-copy" type="button">Copy Invite Link</button>
+          <button class="btn btn-ghost" data-back="menu" type="button">Cancel</button>
+        </div>
+        <p class="hint">
+          On the other device, open this game, tap <strong>Play a Friend → Join With a Code</strong>,
+          and type these letters.
+        </p>
+      </section>
+
+      <!-- Joining: enter a code -->
+      <section class="screen hidden" id="screen-join">
+        <h2 class="heading">Enter the Code</h2>
+        <div class="code-input">
+          <input class="code-box" maxlength="1" inputmode="text" autocomplete="off" aria-label="Code letter 1" />
+          <input class="code-box" maxlength="1" inputmode="text" autocomplete="off" aria-label="Code letter 2" />
+          <input class="code-box" maxlength="1" inputmode="text" autocomplete="off" aria-label="Code letter 3" />
+          <input class="code-box" maxlength="1" inputmode="text" autocomplete="off" aria-label="Code letter 4" />
+        </div>
+        <div class="stack">
+          <button class="btn btn-primary" id="btn-join-go" type="button">Join Game</button>
+          <button class="btn btn-ghost" data-back="friend" type="button">Back</button>
+        </div>
+      </section>
+
+      <!-- Connecting spinner -->
+      <section class="screen hidden" id="screen-connecting">
+        <div class="spinner" aria-hidden="true"></div>
+        <p class="tagline" id="connecting-text">Connecting…</p>
+        <button class="btn btn-ghost" data-back="menu" type="button">Cancel</button>
+      </section>
+
+      <!-- Something went wrong -->
+      <section class="screen hidden" id="screen-error">
+        <h2 class="heading">Hmm.</h2>
+        <p class="tagline" id="error-text"></p>
+        <div class="stack">
+          <button class="btn btn-primary" id="btn-error-solo" type="button">
+            Play the Computer Instead
+          </button>
+          <button class="btn btn-ghost" data-back="menu" type="button">Back to Menu</button>
+        </div>
+      </section>
+
+      <!-- Match over -->
+      <section class="screen screen-bottom hidden" id="screen-over">
+        <div class="stack">
+          <button class="btn btn-primary" id="btn-again" type="button">Play Again</button>
+          <button class="btn btn-ghost" data-back="menu" type="button">Back to Menu</button>
+        </div>
+        <p class="tagline" id="over-status"></p>
+      </section>
+
+      <!-- Waiting for opponent mid-match -->
+      <section class="screen screen-bottom hidden" id="screen-waiting">
+        <div class="spinner" aria-hidden="true"></div>
+        <p class="tagline" id="waiting-text">Waiting for the other player…</p>
+        <p class="hint">Game code: <strong id="waiting-code"></strong></p>
+      </section>
+    </div>
+
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/games/air-hockey/package-lock.json
+++ b/games/air-hockey/package-lock.json
@@ -1,0 +1,1260 @@
+{
+  "name": "air-hockey",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "air-hockey",
+      "version": "1.0.0",
+      "dependencies": {
+        "pixi-filters": "^6.1.0",
+        "pixi.js": "^8.6.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha512-r7K3NkJz3A95WkVVmjs0NcchhHstC2C/VIYNX4JC6tieviUNo774FFeOHjThr3Vw/WCeMP9kAT77MKbIRlO/4w==",
+      "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.2.0.tgz",
+      "integrity": "sha512-Tf7FFIrguPKQwzD4pWnYkR2VOv3raoHeKED80Bm+BYHI3KxC8KsgsGC5+fSMzAGDA6UEk4bHvmi+RsjmL3khpg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi-filters": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/pixi-filters/-/pixi-filters-6.1.5.tgz",
+      "integrity": "sha512-Ewb/J+kxAbaNN+0/ATJbglAJG+skGJfh7BIDP3ILIDdD6wWk1p0pGa25pVf1T8hGBOQSUNVAmwwJBwkj+cyLLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/gradient-parser": "^0.1.2"
+      },
+      "peerDependencies": {
+        "pixi.js": ">=8.0.0-0"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.19.0.tgz",
+      "integrity": "sha512-pq1O6emA/GFjjeF+8d3Pb5t7knD8FsnfWGqQcRjYjsqFZ7QdzG1XgjLDUu0DFJRbafjV5+g8iNLFBx0b9649lg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.13",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.2.0",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/games/air-hockey/package.json
+++ b/games/air-hockey/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "air-hockey",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "pixi-filters": "^6.1.0",
+    "pixi.js": "^8.6.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/games/air-hockey/src/audio.ts
+++ b/games/air-hockey/src/audio.ts
@@ -1,0 +1,136 @@
+/**
+ * Synthesized Web Audio — no asset files. Unlocks on the first user gesture
+ * and remembers the mute setting.
+ */
+
+const MUTE_KEY = 'air-hockey.muted';
+
+class AudioKit {
+  private ctx: AudioContext | null = null;
+  private master: GainNode | null = null;
+  private noiseBuffer: AudioBuffer | null = null;
+  muted = false;
+
+  constructor() {
+    try {
+      this.muted = localStorage.getItem(MUTE_KEY) === '1';
+    } catch {
+      this.muted = false;
+    }
+  }
+
+  unlock(): void {
+    if (this.ctx) {
+      if (this.ctx.state === 'suspended') void this.ctx.resume();
+      return;
+    }
+    type WithWebkit = typeof window & { webkitAudioContext?: typeof AudioContext };
+    const Ctor = window.AudioContext ?? (window as WithWebkit).webkitAudioContext;
+    if (!Ctor) return;
+    this.ctx = new Ctor();
+    this.master = this.ctx.createGain();
+    this.master.gain.value = this.muted ? 0 : 0.5;
+    this.master.connect(this.ctx.destination);
+
+    // One second of white noise, reused for every impact transient.
+    const len = Math.floor(this.ctx.sampleRate);
+    const buf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+    this.noiseBuffer = buf;
+  }
+
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+    try {
+      localStorage.setItem(MUTE_KEY, muted ? '1' : '0');
+    } catch {
+      // Private browsing; the setting just won't persist.
+    }
+    if (this.master && this.ctx) {
+      this.master.gain.setTargetAtTime(muted ? 0 : 0.5, this.ctx.currentTime, 0.02);
+    }
+  }
+
+  private tone(
+    freq: number,
+    duration: number,
+    opts: { type?: OscillatorType; gain?: number; delay?: number; slideTo?: number } = {}
+  ): void {
+    if (!this.ctx || !this.master || this.muted) return;
+    const t0 = this.ctx.currentTime + (opts.delay ?? 0);
+    const osc = this.ctx.createOscillator();
+    const gain = this.ctx.createGain();
+    osc.type = opts.type ?? 'triangle';
+    osc.frequency.setValueAtTime(freq, t0);
+    if (opts.slideTo) osc.frequency.exponentialRampToValueAtTime(opts.slideTo, t0 + duration);
+    const peak = opts.gain ?? 0.3;
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(peak, t0 + 0.008);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + duration);
+    osc.connect(gain).connect(this.master);
+    osc.start(t0);
+    osc.stop(t0 + duration + 0.02);
+  }
+
+  private noise(duration: number, freq: number, gainValue: number): void {
+    if (!this.ctx || !this.master || !this.noiseBuffer || this.muted) return;
+    const t0 = this.ctx.currentTime;
+    const src = this.ctx.createBufferSource();
+    src.buffer = this.noiseBuffer;
+    const filter = this.ctx.createBiquadFilter();
+    filter.type = 'bandpass';
+    filter.frequency.value = freq;
+    filter.Q.value = 1.1;
+    const gain = this.ctx.createGain();
+    gain.gain.setValueAtTime(gainValue, t0);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + duration);
+    src.connect(filter).connect(gain).connect(this.master);
+    src.start(t0);
+    src.stop(t0 + duration + 0.02);
+  }
+
+  paddleHit(power: number): void {
+    const p = Math.max(0.15, Math.min(1, power));
+    this.tone(150 + p * 130, 0.11, { type: 'sine', gain: 0.16 + p * 0.2, slideTo: 70 });
+    this.noise(0.05, 1400 + p * 1800, 0.1 + p * 0.14);
+  }
+
+  wallHit(power: number): void {
+    const p = Math.max(0.1, Math.min(1, power));
+    this.tone(105, 0.08, { type: 'sine', gain: 0.07 + p * 0.11, slideTo: 62 });
+    this.noise(0.035, 900, 0.05 + p * 0.07);
+  }
+
+  post(power: number): void {
+    const p = Math.max(0.1, Math.min(1, power));
+    this.tone(880, 0.24, { type: 'square', gain: 0.05 + p * 0.07 });
+    this.tone(1320, 0.18, { type: 'sine', gain: 0.04 + p * 0.05 });
+  }
+
+  goal(mine: boolean): void {
+    const notes = mine ? [523, 659, 784, 1047] : [392, 330, 262];
+    notes.forEach((f, i) => {
+      this.tone(f, 0.3, { type: 'triangle', gain: 0.26, delay: i * 0.09 });
+    });
+    this.noise(0.3, 500, 0.1);
+  }
+
+  win(won: boolean): void {
+    const notes = won ? [523, 659, 784, 1047, 1319] : [392, 349, 294, 233];
+    notes.forEach((f, i) => {
+      this.tone(f, 0.42, { type: 'triangle', gain: 0.3, delay: i * 0.13 });
+      this.tone(f * 2, 0.34, { type: 'sine', gain: 0.11, delay: i * 0.13 });
+    });
+  }
+
+  countdownBeep(last: boolean): void {
+    this.tone(last ? 880 : 523, last ? 0.3 : 0.13, { type: 'square', gain: 0.16 });
+  }
+
+  uiClick(): void {
+    this.tone(660, 0.07, { type: 'square', gain: 0.1 });
+  }
+}
+
+export const audio = new AudioKit();

--- a/games/air-hockey/src/bot.ts
+++ b/games/air-hockey/src/bot.ts
@@ -1,0 +1,181 @@
+import type { ClientMessage, ServerMessage, Transport } from './protocol';
+import {
+  type Match,
+  type StepEvent,
+  PADDLE_R,
+  PHASE_OVER,
+  PHASE_WAITING,
+  PUCK_R,
+  TABLE_H,
+  TABLE_W,
+  TICK_DT,
+  TICK_RATE,
+  clampPaddleTarget,
+  createMatch,
+  encodeSnapshot,
+  resetMatch,
+  setInput,
+  step,
+} from './shared/rules';
+
+export type Difficulty = 'easy' | 'normal' | 'hard';
+
+/** Longest real-time gap the simulation will try to catch up on, in seconds. */
+const MAX_CATCHUP_SECONDS = 0.25;
+/**
+ * Enough steps to fully drain a MAX_CATCHUP_SECONDS backlog. If this were any
+ * smaller the match would drift into slow motion on a slow device instead of
+ * simply rendering fewer frames.
+ */
+const MAX_CATCHUP_STEPS = Math.ceil(MAX_CATCHUP_SECONDS / TICK_DT);
+
+interface BotConfig {
+  /** Table units per second the bot's hand can travel. */
+  speed: number;
+  /** Seconds of puck movement the bot anticipates. */
+  lead: number;
+  /** Aim wobble, in table units. */
+  noise: number;
+  /** How often the wobble is re-rolled, in seconds. */
+  reaction: number;
+}
+
+const CONFIG: Record<Difficulty, BotConfig> = {
+  // Tuned by feel for a five-year-old: slow enough to beat, quick enough to
+  // look like it's trying.
+  easy: { speed: 74, lead: 0.02, noise: 11, reaction: 0.32 },
+  normal: { speed: 134, lead: 0.07, noise: 6, reaction: 0.17 },
+  hard: { speed: 206, lead: 0.13, noise: 2.5, reaction: 0.07 },
+};
+
+/**
+ * Runs a whole match in the page against a bot, speaking the same protocol as
+ * the Durable Object. Solo play is therefore not a separate code path in the
+ * game — it's the same loop with a different transport.
+ */
+export class BotTransport implements Transport {
+  readonly interpDelayMs = 28;
+  onMessage: ((msg: ServerMessage) => void) | null = null;
+  onError: ((reason: string) => void) | null = null;
+
+  private match: Match = createMatch();
+  private loop: ReturnType<typeof setInterval> | null = null;
+  private readonly cfg: BotConfig;
+
+  // Bot hand position + current aim wobble.
+  private handX = TABLE_W / 2;
+  private handY = PADDLE_R + 14;
+  private noiseX = 0;
+  private noiseY = 0;
+  private noiseTimer = 0;
+  private lastTime = performance.now();
+  private accumulator = 0;
+
+  constructor(difficulty: Difficulty) {
+    this.cfg = CONFIG[difficulty];
+    // Deliver the handshake after construction so callers can attach handlers.
+    setTimeout(() => {
+      this.onMessage?.({ t: 'joined', side: 0, code: 'SOLO', tickRate: TICK_RATE });
+      this.onMessage?.({
+        t: 'roster',
+        names: ['You', 'Computer'],
+        present: [true, true],
+        rematch: [false, false],
+      });
+      resetMatch(this.match);
+      this.loop = setInterval(() => this.tick(), 1000 / TICK_RATE);
+    }, 0);
+  }
+
+  send(msg: ClientMessage): void {
+    switch (msg.t) {
+      case 'input':
+        setInput(this.match, 0, msg.x, msg.y);
+        break;
+      case 'rematch':
+        if (this.match.phase === PHASE_OVER) resetMatch(this.match);
+        break;
+      case 'ping':
+        this.onMessage?.({ t: 'pong', id: msg.id });
+        break;
+    }
+  }
+
+  close(): void {
+    if (this.loop !== null) clearInterval(this.loop);
+    this.loop = null;
+  }
+
+  private tick(): void {
+    if (this.match.phase === PHASE_WAITING) resetMatch(this.match);
+
+    // Catch up on real elapsed time rather than assuming the interval fired on
+    // schedule. A slow device drops frames instead of playing in slow motion.
+    const now = performance.now();
+    const elapsed = Math.min((now - this.lastTime) / 1000, MAX_CATCHUP_SECONDS);
+    this.lastTime = now;
+    this.accumulator += elapsed;
+
+    const events: StepEvent[] = [];
+    let steps = 0;
+    while (this.accumulator >= TICK_DT && steps < MAX_CATCHUP_STEPS) {
+      this.accumulator -= TICK_DT;
+      steps++;
+      this.driveBot(TICK_DT);
+      events.push(...step(this.match, TICK_DT));
+    }
+    if (steps === 0) return;
+
+    this.onMessage?.({
+      t: 'snap',
+      s: encodeSnapshot(this.match),
+      ...(events.length ? { e: events } : {}),
+    });
+  }
+
+  private driveBot(dt: number): void {
+    const { puck } = this.match;
+    const cfg = this.cfg;
+
+    this.noiseTimer -= dt;
+    if (this.noiseTimer <= 0) {
+      this.noiseTimer = cfg.reaction;
+      this.noiseX = (Math.random() * 2 - 1) * cfg.noise;
+      this.noiseY = (Math.random() * 2 - 1) * cfg.noise * 0.6;
+    }
+
+    const homeY = PADDLE_R + 14;
+    let wantX: number;
+    let wantY: number;
+
+    if (puck.y < TABLE_H * 0.55) {
+      // Puck is in reach — line up behind it so the hit goes downfield.
+      wantX = puck.x + puck.vx * cfg.lead;
+      wantY = puck.y + puck.vy * cfg.lead - (PADDLE_R + PUCK_R) * 0.8;
+    } else {
+      // Puck is down the other end — shadow it from the goal line.
+      wantX = TABLE_W / 2 + (puck.x - TABLE_W / 2) * 0.35;
+      wantY = homeY;
+    }
+
+    wantX += this.noiseX;
+    wantY += this.noiseY;
+
+    const dx = wantX - this.handX;
+    const dy = wantY - this.handY;
+    const d = Math.hypot(dx, dy);
+    const maxStep = cfg.speed * dt;
+    if (d > maxStep && d > 0) {
+      this.handX += (dx / d) * maxStep;
+      this.handY += (dy / d) * maxStep;
+    } else {
+      this.handX = wantX;
+      this.handY = wantY;
+    }
+
+    const clamped = clampPaddleTarget(1, this.handX, this.handY);
+    this.handX = clamped.x;
+    this.handY = clamped.y;
+    setInput(this.match, 1, this.handX, this.handY);
+  }
+}

--- a/games/air-hockey/src/fx.ts
+++ b/games/air-hockey/src/fx.ts
@@ -1,0 +1,138 @@
+import { Container, Graphics, Sprite, Texture, type Renderer } from 'pixi.js';
+
+interface Particle {
+  sprite: Sprite;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  spin: number;
+  drag: number;
+  startScale: number;
+}
+
+const POOL_SIZE = 700;
+
+export interface BurstOptions {
+  color?: number;
+  /** Peak outward speed, px/s. */
+  speed?: number;
+  life?: number;
+  size?: number;
+  /** Restrict the spray to a cone around this angle (radians). */
+  direction?: number;
+  spread?: number;
+  gravity?: number;
+}
+
+/** Pooled additive particles plus a shared screen-shake accumulator. */
+export class Fx {
+  private readonly layer = new Container();
+  private readonly pool: Particle[] = [];
+  private readonly active: Particle[] = [];
+  private trauma = 0;
+  shakeX = 0;
+  shakeY = 0;
+
+  constructor(renderer: Renderer, parent: Container) {
+    this.layer.blendMode = 'add';
+    parent.addChild(this.layer);
+
+    const dot = new Graphics().circle(0, 0, 16).fill({ color: 0xffffff });
+    const texture: Texture = renderer.generateTexture({
+      target: dot,
+      resolution: 2,
+      antialias: true,
+    });
+    dot.destroy();
+
+    for (let i = 0; i < POOL_SIZE; i++) {
+      const sprite = new Sprite(texture);
+      sprite.anchor.set(0.5);
+      sprite.visible = false;
+      this.layer.addChild(sprite);
+      this.pool.push({
+        sprite,
+        vx: 0,
+        vy: 0,
+        life: 0,
+        maxLife: 1,
+        spin: 0,
+        drag: 1,
+        startScale: 1,
+      });
+    }
+  }
+
+  burst(x: number, y: number, count: number, opts: BurstOptions = {}): void {
+    const color = opts.color ?? 0xffffff;
+    const speed = opts.speed ?? 260;
+    const life = opts.life ?? 0.5;
+    const size = opts.size ?? 5;
+    const spread = opts.spread ?? Math.PI * 2;
+    const dir = opts.direction ?? 0;
+
+    for (let i = 0; i < count; i++) {
+      const p = this.pool.pop();
+      if (!p) return; // Pool exhausted — dropping particles beats stuttering.
+      const angle = dir + (Math.random() - 0.5) * spread;
+      const mag = speed * (0.35 + Math.random() * 0.65);
+      p.vx = Math.cos(angle) * mag;
+      p.vy = Math.sin(angle) * mag;
+      p.maxLife = life * (0.6 + Math.random() * 0.7);
+      p.life = p.maxLife;
+      p.drag = opts.gravity !== undefined ? 1.6 : 2.6;
+      p.spin = opts.gravity ?? 0;
+      p.startScale = (size * (0.5 + Math.random() * 0.8)) / 16;
+
+      p.sprite.visible = true;
+      p.sprite.position.set(x, y);
+      p.sprite.tint = color;
+      p.sprite.alpha = 1;
+      p.sprite.scale.set(p.startScale);
+      this.active.push(p);
+    }
+  }
+
+  /** Adds screen shake. `amount` is roughly 0..1. */
+  addShake(amount: number): void {
+    this.trauma = Math.min(1, this.trauma + amount);
+  }
+
+  update(dt: number): void {
+    for (let i = this.active.length - 1; i >= 0; i--) {
+      const p = this.active[i];
+      p.life -= dt;
+      if (p.life <= 0) {
+        p.sprite.visible = false;
+        this.active.splice(i, 1);
+        this.pool.push(p);
+        continue;
+      }
+      const decay = Math.exp(-p.drag * dt);
+      p.vx *= decay;
+      p.vy = p.vy * decay + p.spin * dt;
+      p.sprite.x += p.vx * dt;
+      p.sprite.y += p.vy * dt;
+      const t = p.life / p.maxLife;
+      p.sprite.alpha = t;
+      p.sprite.scale.set(p.startScale * (0.35 + t * 0.75));
+    }
+
+    this.trauma = Math.max(0, this.trauma - dt * 1.6);
+    const mag = this.trauma * this.trauma * 16;
+    this.shakeX = (Math.random() * 2 - 1) * mag;
+    this.shakeY = (Math.random() * 2 - 1) * mag;
+  }
+
+  clear(): void {
+    for (const p of this.active) {
+      p.sprite.visible = false;
+      this.pool.push(p);
+    }
+    this.active.length = 0;
+    this.trauma = 0;
+    this.shakeX = 0;
+    this.shakeY = 0;
+  }
+}

--- a/games/air-hockey/src/main.ts
+++ b/games/air-hockey/src/main.ts
@@ -1,0 +1,542 @@
+import { Application } from 'pixi.js';
+import { audio } from './audio';
+import { BotTransport, type Difficulty } from './bot';
+import { OnlineTransport, probeServer, resolveServerBase } from './net';
+import type { ServerMessage, Transport } from './protocol';
+import { Ui, type ScreenName } from './ui';
+import { VIEW_H, VIEW_W, View, type RenderState } from './view';
+import {
+  type Match,
+  type Phase,
+  type Side,
+  type StepEvent,
+  PADDLE_R,
+  PHASE_COUNTDOWN,
+  PHASE_OVER,
+  PHASE_PLAY,
+  PHASE_WAITING,
+  TABLE_H,
+  TABLE_W,
+  advancePaddle,
+  clampPaddleTarget,
+  decodeSnapshot,
+  isValidCode,
+  randomCode,
+} from './shared/rules';
+
+type Mode = 'idle' | 'solo' | 'online';
+
+interface BufferedSnapshot {
+  recvAt: number;
+  match: Match;
+}
+
+// --- Session state ---------------------------------------------------------
+
+let transport: Transport | null = null;
+let mode: Mode = 'idle';
+let mySide: Side = 0;
+let isHost = false;
+let everStarted = false;
+let roomCode = '';
+
+let buffer: BufferedSnapshot[] = [];
+let eventQueue: { dueAt: number; event: StepEvent }[] = [];
+
+/** Where the pointer is asking our paddle to go, in table units. */
+let localTarget = { x: TABLE_W / 2, y: TABLE_H - PADDLE_R - 12 };
+/** Locally predicted paddle position, so our own paddle never lags. */
+let localPaddle = { ...localTarget };
+
+let opponentPresent = false;
+let names: [string, string] = ['You', 'Opponent'];
+let rematchFlags: [boolean, boolean] = [false, false];
+let lastCountdownBeep = -1;
+let sinceInputSend = 0;
+const keys = new Set<string>();
+
+// --- Boot ------------------------------------------------------------------
+
+async function boot(): Promise<void> {
+  const app = new Application();
+  await app.init({
+    width: VIEW_W,
+    height: VIEW_H,
+    backgroundColor: 0x04060f,
+    antialias: true,
+    resolution: Math.min(window.devicePixelRatio || 1, 1.5),
+    autoDensity: true,
+  });
+
+  const host = document.getElementById('app');
+  if (!host) throw new Error('missing #app');
+  host.appendChild(app.canvas);
+
+  // Fixed logical resolution, CSS-scaled to fit the window.
+  const resize = (): void => {
+    const scale = Math.min(window.innerWidth / VIEW_W, window.innerHeight / VIEW_H);
+    app.canvas.style.width = `${Math.floor(VIEW_W * scale)}px`;
+    app.canvas.style.height = `${Math.floor(VIEW_H * scale)}px`;
+  };
+  window.addEventListener('resize', resize);
+  resize();
+
+  const view = new View(app);
+  const ui = new Ui();
+
+  wireInput(app, view);
+  wireUi(ui, view);
+
+  app.ticker.add(() => {
+    const dt = Math.min(app.ticker.deltaMS, 100) / 1000;
+    frame(dt, view, ui);
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      // Coming back from a background tab: the buffer is stale, so drop it
+      // rather than interpolating across a multi-second gap.
+      buffer = [];
+      eventQueue = [];
+    }
+  });
+
+  ui.show('menu');
+
+  // A shared invite link lands here with #CODE.
+  const hash = location.hash.replace('#', '').toUpperCase();
+  if (isValidCode(hash)) {
+    ui.show('join');
+    ui.prefillCode(hash);
+    void startJoin(hash, ui, view);
+  }
+
+  // Debug hook for the Playwright smoke test — headless renderers are far too
+  // slow to assert on wall-clock timing, so assert on state instead.
+  (window as unknown as { __game?: unknown }).__game = {
+    get mode() {
+      return mode;
+    },
+    get side() {
+      return mySide;
+    },
+    get code() {
+      return roomCode;
+    },
+    get opponentPresent() {
+      return opponentPresent;
+    },
+    get snapshot() {
+      return buffer.length ? buffer[buffer.length - 1].match : null;
+    },
+    get serverBase() {
+      return resolveServerBase();
+    },
+    setTarget(x: number, y: number) {
+      localTarget = clampPaddleTarget(mySide, x, y);
+    },
+  };
+}
+
+// --- Input -----------------------------------------------------------------
+
+function wireInput(app: Application, view: View): void {
+  const canvas = app.canvas;
+
+  const toLogical = (clientX: number, clientY: number): { x: number; y: number } => {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((clientX - rect.left) / rect.width) * VIEW_W,
+      y: ((clientY - rect.top) / rect.height) * VIEW_H,
+    };
+  };
+
+  const aim = (clientX: number, clientY: number): void => {
+    const logical = toLogical(clientX, clientY);
+    const table = view.toTable(logical.x, logical.y);
+    localTarget = clampPaddleTarget(mySide, table.x, table.y);
+  };
+
+  // Listening on the window (not the canvas) means the paddle keeps tracking
+  // even when a finger strays into the letterbox area.
+  window.addEventListener('pointermove', (e) => {
+    if (mode === 'idle') return;
+    aim(e.clientX, e.clientY);
+  });
+  window.addEventListener(
+    'pointerdown',
+    (e) => {
+      audio.unlock();
+      if (mode === 'idle') return;
+      aim(e.clientX, e.clientY);
+    },
+    { passive: true }
+  );
+
+  window.addEventListener('keydown', (e) => {
+    keys.add(e.key.toLowerCase());
+    if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' '].includes(e.key.toLowerCase())) {
+      e.preventDefault();
+    }
+  });
+  window.addEventListener('keyup', (e) => keys.delete(e.key.toLowerCase()));
+  window.addEventListener('blur', () => keys.clear());
+}
+
+/** Keyboard is a fallback for laptops without a comfortable mouse. */
+function applyKeyboard(dt: number): void {
+  const speed = 95 * dt;
+  let dx = 0;
+  let dy = 0;
+  if (keys.has('arrowleft') || keys.has('a')) dx -= 1;
+  if (keys.has('arrowright') || keys.has('d')) dx += 1;
+  if (keys.has('arrowup') || keys.has('w')) dy -= 1;
+  if (keys.has('arrowdown') || keys.has('s')) dy += 1;
+  if (dx === 0 && dy === 0) return;
+  const len = Math.hypot(dx, dy);
+  // The view is flipped for side 1, so "up" on the keyboard is -y on screen
+  // but +y in table space.
+  const sign = mySide === 1 ? -1 : 1;
+  localTarget = clampPaddleTarget(
+    mySide,
+    localTarget.x + (dx / len) * speed * sign,
+    localTarget.y + (dy / len) * speed * sign
+  );
+}
+
+// --- UI wiring -------------------------------------------------------------
+
+function wireUi(ui: Ui, view: View): void {
+  ui.onSolo = (difficulty) => startSolo(difficulty, ui, view);
+  ui.onHost = () => void startHost(ui, view);
+  ui.onJoin = (code) => void startJoin(code, ui, view);
+  ui.onQuit = () => quitToMenu(ui);
+  ui.onRematch = () => {
+    transport?.send({ t: 'rematch' });
+    if (mode === 'online') ui.setOverStatus('Waiting for the other player…');
+  };
+}
+
+function teardown(): void {
+  transport?.close();
+  transport = null;
+  buffer = [];
+  eventQueue = [];
+  opponentPresent = false;
+  everStarted = false;
+  rematchFlags = [false, false];
+  lastCountdownBeep = -1;
+}
+
+function quitToMenu(ui: Ui): void {
+  teardown();
+  mode = 'idle';
+  roomCode = '';
+  if (location.hash) history.replaceState(null, '', location.pathname + location.search);
+  ui.setOverStatus('');
+  ui.show('menu');
+}
+
+function resetLocalPaddle(side: Side): void {
+  const home = { x: TABLE_W / 2, y: side === 0 ? TABLE_H - PADDLE_R - 12 : PADDLE_R + 12 };
+  localTarget = { ...home };
+  localPaddle = { ...home };
+}
+
+function attach(t: Transport, ui: Ui, view: View): void {
+  transport = t;
+  t.onMessage = (msg) => handleMessage(msg, ui, view);
+  t.onError = (reason) => {
+    teardown();
+    mode = 'idle';
+    ui.setError(reason);
+  };
+}
+
+function startSolo(difficulty: Difficulty, ui: Ui, view: View): void {
+  teardown();
+  mode = 'solo';
+  isHost = false;
+  roomCode = '';
+  names = ['You', 'Computer'];
+  opponentPresent = true;
+  everStarted = true;
+  resetLocalPaddle(0);
+  view.setSide(0);
+  view.setNames(names);
+  ui.setConnectionInfo('Solo · ' + difficulty);
+  ui.setOverStatus('');
+  ui.show('none');
+  attach(new BotTransport(difficulty), ui, view);
+}
+
+async function startHost(ui: Ui, view: View): Promise<void> {
+  ui.setConnectingText('Setting up your game…');
+  ui.show('connecting');
+
+  if (!(await probeServer())) {
+    ui.setError(
+      "Two-player mode isn't set up on this server yet, so a friend can't join right now."
+    );
+    return;
+  }
+
+  const code = randomCode();
+  teardown();
+  mode = 'online';
+  isHost = true;
+  roomCode = code;
+  ui.setHostCode(code);
+  ui.setHostStatus('Waiting for the other player…');
+  ui.setOverStatus('');
+  ui.show('host');
+  attach(new OnlineTransport(code, 'Player 1'), ui, view);
+}
+
+async function startJoin(code: string, ui: Ui, view: View): Promise<void> {
+  ui.setConnectingText('Joining the game…');
+  ui.show('connecting');
+
+  if (!isValidCode(code)) {
+    ui.setError("That code doesn't look right. Codes are 4 letters or numbers.");
+    return;
+  }
+  if (!(await probeServer())) {
+    ui.setError("Two-player mode isn't set up on this server yet.");
+    return;
+  }
+
+  teardown();
+  mode = 'online';
+  isHost = false;
+  roomCode = code;
+  ui.setOverStatus('');
+  attach(new OnlineTransport(code, 'Player 2'), ui, view);
+}
+
+// --- Messages --------------------------------------------------------------
+
+function handleMessage(msg: ServerMessage, ui: Ui, view: View): void {
+  switch (msg.t) {
+    case 'joined': {
+      mySide = msg.side;
+      roomCode = msg.code;
+      resetLocalPaddle(mySide);
+      view.setSide(mySide);
+      view.setNames(names);
+      break;
+    }
+    case 'roster': {
+      names = msg.names.map((n, i) => n || (i === mySide ? 'You' : 'Waiting…')) as [string, string];
+      if (mode === 'solo') names = ['You', 'Computer'];
+      rematchFlags = msg.rematch;
+      opponentPresent = msg.present[mySide === 0 ? 1 : 0];
+      if (opponentPresent) everStarted = true;
+      view.setNames(names);
+      if (mode === 'online') {
+        ui.setOverStatus(
+          rematchFlags[mySide] && !rematchFlags[mySide === 0 ? 1 : 0]
+            ? 'Waiting for the other player…'
+            : ''
+        );
+      }
+      break;
+    }
+    case 'snap': {
+      const now = performance.now();
+      buffer.push({ recvAt: now, match: decodeSnapshot(msg.s) });
+      // Two seconds of history is far more than interpolation needs.
+      while (buffer.length > 2 && now - buffer[0].recvAt > 2000) buffer.shift();
+      if (msg.e && transport) {
+        const dueAt = now + transport.interpDelayMs;
+        for (const event of msg.e) eventQueue.push({ dueAt, event });
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+// --- Interpolation ---------------------------------------------------------
+
+function toRenderState(m: Match): RenderState {
+  return {
+    puck: { x: m.puck.x, y: m.puck.y },
+    paddles: [
+      { x: m.paddles[0].x, y: m.paddles[0].y },
+      { x: m.paddles[1].x, y: m.paddles[1].y },
+    ],
+    scores: [m.scores[0], m.scores[1]],
+    phase: m.phase,
+    timer: m.timer,
+    winner: m.winner,
+  };
+}
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+function sampleBuffer(now: number, delayMs: number): RenderState | null {
+  if (buffer.length === 0) return null;
+  const renderTime = now - delayMs;
+  const last = buffer[buffer.length - 1];
+  if (buffer.length === 1 || renderTime >= last.recvAt) return toRenderState(last.match);
+  if (renderTime <= buffer[0].recvAt) return toRenderState(buffer[0].match);
+
+  for (let i = buffer.length - 2; i >= 0; i--) {
+    const a = buffer[i];
+    const b = buffer[i + 1];
+    if (renderTime < a.recvAt) continue;
+    const span = Math.max(1, b.recvAt - a.recvAt);
+    const t = Math.min(1, Math.max(0, (renderTime - a.recvAt) / span));
+
+    // Discrete state comes from the older snapshot so that scores and phase
+    // change in step with the puck position being drawn.
+    const out = toRenderState(a.match);
+    out.timer = lerp(a.match.timer, b.match.timer, t);
+
+    // A goal teleports the puck back to centre; never interpolate across that.
+    const jump = Math.hypot(b.match.puck.x - a.match.puck.x, b.match.puck.y - a.match.puck.y);
+    if (jump < 30) {
+      out.puck.x = lerp(a.match.puck.x, b.match.puck.x, t);
+      out.puck.y = lerp(a.match.puck.y, b.match.puck.y, t);
+    }
+    for (const side of [0, 1] as Side[]) {
+      out.paddles[side].x = lerp(a.match.paddles[side].x, b.match.paddles[side].x, t);
+      out.paddles[side].y = lerp(a.match.paddles[side].y, b.match.paddles[side].y, t);
+    }
+    return out;
+  }
+  return toRenderState(last.match);
+}
+
+// --- Frame -----------------------------------------------------------------
+
+function frame(dt: number, view: View, ui: Ui): void {
+  const now = performance.now();
+
+  if (mode !== 'idle') {
+    applyKeyboard(dt);
+    localPaddle = advancePaddle(mySide, localPaddle, localTarget.x, localTarget.y, dt);
+
+    sinceInputSend += dt;
+    if (sinceInputSend >= 0.02) {
+      sinceInputSend = 0;
+      transport?.send({ t: 'input', x: localTarget.x, y: localTarget.y });
+    }
+  }
+
+  // Fire buffered events at the moment the frames they belong to are drawn.
+  while (eventQueue.length > 0 && eventQueue[0].dueAt <= now) {
+    const { event } = eventQueue.shift()!;
+    playEvent(event, view);
+  }
+
+  const state = mode === 'idle' ? null : sampleBuffer(now, transport?.interpDelayMs ?? 60);
+  if (state) {
+    // Draw our own paddle from local prediction rather than the delayed
+    // snapshot, unless the two have drifted so far that something is wrong.
+    const authoritative = state.paddles[mySide];
+    if (Math.hypot(authoritative.x - localPaddle.x, authoritative.y - localPaddle.y) > 14) {
+      localPaddle = { x: authoritative.x, y: authoritative.y };
+    }
+    state.paddles[mySide] = { x: localPaddle.x, y: localPaddle.y };
+
+    handleCountdownAudio(state.phase, state.timer);
+    refreshScreens(state.phase, ui);
+    updateConnectionChip(ui, state.phase);
+    view.render(state, dt);
+  } else {
+    // Nothing to show yet (menu, or still connecting) — keep particles alive.
+    view.render(idleState(), dt);
+  }
+}
+
+function idleState(): RenderState {
+  return {
+    puck: { x: TABLE_W / 2, y: TABLE_H / 2 },
+    paddles: [
+      { x: TABLE_W / 2, y: TABLE_H - PADDLE_R - 12 },
+      { x: TABLE_W / 2, y: PADDLE_R + 12 },
+    ],
+    scores: [0, 0],
+    phase: PHASE_WAITING,
+    timer: 0,
+    winner: -1,
+  };
+}
+
+function handleCountdownAudio(phase: Phase, timer: number): void {
+  if (phase !== PHASE_COUNTDOWN) {
+    if (phase === PHASE_PLAY && lastCountdownBeep !== 0) {
+      lastCountdownBeep = 0;
+      audio.countdownBeep(true);
+    }
+    if (phase !== PHASE_PLAY) lastCountdownBeep = -1;
+    return;
+  }
+  const n = Math.ceil(timer);
+  if (n !== lastCountdownBeep && n > 0) {
+    lastCountdownBeep = n;
+    audio.countdownBeep(false);
+  }
+}
+
+function playEvent(event: StepEvent, view: View): void {
+  view.impact(event.kind, event.x, event.y, event.power, event.side);
+  switch (event.kind) {
+    case 'paddle':
+      audio.paddleHit(event.power);
+      break;
+    case 'wall':
+      audio.wallHit(event.power);
+      break;
+    case 'post':
+      audio.post(event.power);
+      break;
+    case 'goal':
+      audio.goal(event.side === mySide);
+      break;
+    case 'win':
+      audio.win(event.side === mySide);
+      view.celebrate(event.side === mySide);
+      break;
+  }
+}
+
+function refreshScreens(phase: Phase, ui: Ui): void {
+  if (mode === 'idle') return;
+
+  let desired: ScreenName;
+  if (phase === PHASE_OVER) {
+    desired = 'over';
+  } else if (mode === 'online' && !opponentPresent) {
+    if (isHost && !everStarted) {
+      desired = 'host';
+    } else {
+      ui.setWaitingText(
+        everStarted
+          ? 'The other player left. Waiting for them to come back…'
+          : 'Waiting for the other player…'
+      );
+      desired = 'waiting';
+    }
+  } else {
+    desired = 'none';
+  }
+
+  if (ui.screen !== desired) ui.show(desired);
+}
+
+function updateConnectionChip(ui: Ui, phase: Phase): void {
+  if (mode === 'solo') return;
+  const t = transport;
+  if (t instanceof OnlineTransport) {
+    const ping = t.latencyMs > 0 ? `${Math.round(t.latencyMs)}ms` : '…';
+    ui.setConnectionInfo(`${roomCode} · ${ping}`);
+  } else if (phase === PHASE_WAITING) {
+    ui.setConnectionInfo(roomCode);
+  }
+}
+
+void boot();

--- a/games/air-hockey/src/net.ts
+++ b/games/air-hockey/src/net.ts
@@ -1,0 +1,145 @@
+import type { ClientMessage, ServerMessage, Transport } from './protocol';
+import { CODE_LENGTH } from './shared/rules';
+
+/**
+ * Resolve the multiplayer server, in priority order:
+ *   1. `?server=` — for local testing against `wrangler dev`
+ *   2. `VITE_MP_SERVER_URL` — baked in at build time by CI
+ *   3. `<same origin>/mp` — works if the Worker is mounted on a route
+ */
+export function resolveServerBase(): string {
+  const override = new URLSearchParams(location.search).get('server');
+  const configured = import.meta.env.VITE_MP_SERVER_URL as string | undefined;
+  const raw = override || configured || `${location.origin}/mp`;
+  return raw.replace(/\/+$/, '');
+}
+
+function toWebSocketUrl(base: string, path: string): string {
+  const url = new URL(base + path, location.href);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : url.protocol === 'http:' ? 'ws:' : url.protocol;
+  return url.toString();
+}
+
+/**
+ * Is a multiplayer server actually reachable? Checked before showing a kid a
+ * room code, so a misconfigured deploy says so immediately instead of after
+ * they've read four letters out loud to their sibling.
+ */
+export async function probeServer(timeoutMs = 4000): Promise<boolean> {
+  const base = resolveServerBase();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const url = new URL(base + '/health', location.href);
+    url.protocol = url.protocol === 'wss:' ? 'https:' : url.protocol === 'ws:' ? 'http:' : url.protocol;
+    const res = await fetch(url.toString(), { signal: controller.signal });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { ok?: boolean };
+    return body.ok === true;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export class OnlineTransport implements Transport {
+  readonly interpDelayMs = 95;
+  onMessage: ((msg: ServerMessage) => void) | null = null;
+  onError: ((reason: string) => void) | null = null;
+
+  private socket: WebSocket | null = null;
+  private closedByUs = false;
+  private opened = false;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  /** Smoothed round-trip time in ms, shown in the HUD. */
+  latencyMs = 0;
+
+  constructor(
+    readonly code: string,
+    private readonly name: string
+  ) {
+    if (code.length !== CODE_LENGTH) throw new Error('bad code');
+    this.connect();
+  }
+
+  private connect(): void {
+    const url = toWebSocketUrl(
+      resolveServerBase(),
+      `/room/${this.code}?name=${encodeURIComponent(this.name)}`
+    );
+
+    let socket: WebSocket;
+    try {
+      socket = new WebSocket(url);
+    } catch {
+      this.onError?.("Couldn't reach the game server.");
+      return;
+    }
+    this.socket = socket;
+
+    // A server that never completes the handshake would otherwise hang the
+    // "waiting for player 2" screen forever.
+    const openTimeout = setTimeout(() => {
+      if (!this.opened) {
+        this.closedByUs = true;
+        socket.close();
+        this.onError?.("Couldn't reach the game server.");
+      }
+    }, 8000);
+
+    socket.addEventListener('open', () => {
+      this.opened = true;
+      clearTimeout(openTimeout);
+      this.pingTimer = setInterval(() => {
+        this.send({ t: 'ping', id: Math.floor(performance.now()) });
+      }, 2000);
+    });
+
+    socket.addEventListener('message', (event) => {
+      let msg: ServerMessage;
+      try {
+        msg = JSON.parse(event.data as string) as ServerMessage;
+      } catch {
+        return;
+      }
+      if (msg.t === 'pong') {
+        const rtt = performance.now() - msg.id;
+        this.latencyMs = this.latencyMs === 0 ? rtt : this.latencyMs * 0.7 + rtt * 0.3;
+        return;
+      }
+      if (msg.t === 'full') {
+        this.closedByUs = true;
+        this.onError?.('That game already has two players.');
+        return;
+      }
+      this.onMessage?.(msg);
+    });
+
+    socket.addEventListener('close', () => {
+      clearTimeout(openTimeout);
+      if (this.pingTimer !== null) clearInterval(this.pingTimer);
+      this.pingTimer = null;
+      if (!this.closedByUs) {
+        this.onError?.(this.opened ? 'Lost connection to the game.' : "Couldn't reach the game server.");
+      }
+    });
+
+    socket.addEventListener('error', () => {
+      // `close` always follows; reporting here too would double up.
+    });
+  }
+
+  send(msg: ClientMessage): void {
+    if (this.socket?.readyState !== WebSocket.OPEN) return;
+    this.socket.send(JSON.stringify(msg));
+  }
+
+  close(): void {
+    this.closedByUs = true;
+    if (this.pingTimer !== null) clearInterval(this.pingTimer);
+    this.pingTimer = null;
+    this.socket?.close();
+    this.socket = null;
+  }
+}

--- a/games/air-hockey/src/protocol.ts
+++ b/games/air-hockey/src/protocol.ts
@@ -1,0 +1,33 @@
+import type { Side, Snapshot, StepEvent } from './shared/rules';
+
+export type ClientMessage =
+  | { t: 'input'; x: number; y: number }
+  | { t: 'rematch' }
+  | { t: 'ping'; id: number };
+
+export type ServerMessage =
+  | { t: 'joined'; side: Side; code: string; tickRate: number }
+  | { t: 'roster'; names: [string, string]; present: [boolean, boolean]; rematch: [boolean, boolean] }
+  | { t: 'snap'; s: Snapshot; e?: StepEvent[] }
+  | { t: 'pong'; id: number }
+  | { t: 'full' };
+
+/**
+ * Everything the game loop needs from "a thing that runs a match".
+ *
+ * Implemented twice — once over a WebSocket to the Durable Object, once
+ * entirely in-page against a bot — so `main.ts` never branches on game mode.
+ */
+export interface Transport {
+  send(msg: ClientMessage): void;
+  close(): void;
+  /**
+   * How far behind the newest snapshot to render, in ms. Buffered
+   * interpolation needs at least one snapshot interval of slack; online play
+   * needs more to ride out jitter.
+   */
+  readonly interpDelayMs: number;
+  onMessage: ((msg: ServerMessage) => void) | null;
+  /** Called with a human-readable reason when the match can't continue. */
+  onError: ((reason: string) => void) | null;
+}

--- a/games/air-hockey/src/shared/rules.ts
+++ b/games/air-hockey/src/shared/rules.ts
@@ -1,0 +1,585 @@
+/**
+ * Authoritative air-hockey simulation.
+ *
+ * This module is imported by BOTH:
+ *   - the game client (`games/air-hockey`) for solo-vs-bot play and for
+ *     clamping the local paddle during online play, and
+ *   - the Cloudflare Durable Object (`multiplayer-server`) that hosts online
+ *     matches.
+ *
+ * It therefore has to stay dependency-free and side-effect-free. It lives
+ * inside the game directory (rather than next to the worker) so that editing
+ * the rules correctly invalidates the monorepo build cache, which only hashes
+ * `games/<slug>/`.
+ */
+
+// --- Table geometry (arbitrary units; the client scales these to pixels) ---
+
+export const TABLE_W = 100;
+export const TABLE_H = 160;
+export const GOAL_HALF_W = 19;
+export const PUCK_R = 3.6;
+export const PADDLE_R = 6.4;
+
+export const TARGET_SCORE = 7;
+
+export const TICK_RATE = 60;
+export const TICK_DT = 1 / TICK_RATE;
+
+// --- Tuning. Deliberately forgiving: the youngest player here is five. ---
+
+const WALL_BOUNCE = 0.95;
+const PADDLE_BOUNCE = 0.94;
+const PUCK_DRAG = 0.22; // per second, applied exponentially
+const PUCK_MAX_SPEED = 172;
+const PUCK_MIN_BOUNCE_SPEED = 14; // stops the puck dying against a paddle
+const SERVE_SPEED = 44;
+const PADDLE_MAX_SPEED = 260;
+const PADDLE_PUSH = 7; // so a gentle tap still sends the puck away
+
+const COUNTDOWN_TIME = 2.2;
+const GOAL_PAUSE = 1.7;
+
+// A paddle held against a wall can pin the puck: the wall clamp and the
+// paddle's outward push cancel each other out every tick and the puck stops
+// dead. Kids do this constantly (usually in a corner, usually on purpose), so
+// the simulation watches for a puck that has stopped going anywhere and
+// squirts it back out.
+const STUCK_TICKS = 90; // 1.5s at 60Hz
+const STUCK_DISTANCE = 4; // table units of travel that counts as "moving"
+
+// --- Phases ---
+
+export const PHASE_WAITING = 0;
+export const PHASE_COUNTDOWN = 1;
+export const PHASE_PLAY = 2;
+export const PHASE_GOAL = 3;
+export const PHASE_OVER = 4;
+
+export type Phase =
+  | typeof PHASE_WAITING
+  | typeof PHASE_COUNTDOWN
+  | typeof PHASE_PLAY
+  | typeof PHASE_GOAL
+  | typeof PHASE_OVER;
+
+/** 0 defends the bottom edge (y = TABLE_H); 1 defends the top edge (y = 0). */
+export type Side = 0 | 1;
+
+export interface Paddle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** Where this player's pointer is asking the paddle to go. */
+  tx: number;
+  ty: number;
+}
+
+export interface Puck {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+export interface Match {
+  puck: Puck;
+  paddles: [Paddle, Paddle];
+  scores: [number, number];
+  phase: Phase;
+  /** Seconds left in the countdown / goal celebration. */
+  timer: number;
+  /** Which side the next serve drifts toward. */
+  serveTo: Side;
+  winner: Side | -1;
+  tick: number;
+  /** Consecutive ticks the puck has failed to travel STUCK_DISTANCE. */
+  stuckTicks: number;
+  stuckRefX: number;
+  stuckRefY: number;
+}
+
+export type EventKind = 'wall' | 'paddle' | 'goal' | 'post' | 'win';
+
+export interface StepEvent {
+  kind: EventKind;
+  x: number;
+  y: number;
+  /** 0..1 impact strength, for particles / sound / shake. */
+  power: number;
+  side: Side;
+}
+
+// --- Helpers ---
+
+const clamp = (v: number, lo: number, hi: number): number =>
+  v < lo ? lo : v > hi ? hi : v;
+
+/** Vertical band a side's paddle is allowed to occupy (its own half only). */
+export function paddleBounds(side: Side): { minY: number; maxY: number } {
+  return side === 0
+    ? { minY: TABLE_H / 2 + PADDLE_R, maxY: TABLE_H - PADDLE_R }
+    : { minY: PADDLE_R, maxY: TABLE_H / 2 - PADDLE_R };
+}
+
+/** Clamp a requested paddle position into the legal area for that side. */
+export function clampPaddleTarget(
+  side: Side,
+  x: number,
+  y: number
+): { x: number; y: number } {
+  const { minY, maxY } = paddleBounds(side);
+  return {
+    x: clamp(x, PADDLE_R, TABLE_W - PADDLE_R),
+    y: clamp(y, minY, maxY),
+  };
+}
+
+/**
+ * Move a paddle one step toward a requested position under the same speed
+ * limit the server applies. The client uses this to draw the local paddle
+ * immediately instead of waiting a round trip for it to come back.
+ */
+export function advancePaddle(
+  side: Side,
+  cur: { x: number; y: number },
+  tx: number,
+  ty: number,
+  dt: number
+): { x: number; y: number } {
+  const t = clampPaddleTarget(side, tx, ty);
+  let dx = t.x - cur.x;
+  let dy = t.y - cur.y;
+  const d = Math.hypot(dx, dy);
+  const maxStep = PADDLE_MAX_SPEED * dt;
+  if (d > maxStep && d > 0) {
+    dx = (dx / d) * maxStep;
+    dy = (dy / d) * maxStep;
+  }
+  return { x: cur.x + dx, y: cur.y + dy };
+}
+
+function homePosition(side: Side): { x: number; y: number } {
+  return {
+    x: TABLE_W / 2,
+    y: side === 0 ? TABLE_H - PADDLE_R - 12 : PADDLE_R + 12,
+  };
+}
+
+function makePaddle(side: Side): Paddle {
+  const home = homePosition(side);
+  return { x: home.x, y: home.y, vx: 0, vy: 0, tx: home.x, ty: home.y };
+}
+
+export function createMatch(): Match {
+  const match: Match = {
+    puck: { x: TABLE_W / 2, y: TABLE_H / 2, vx: 0, vy: 0 },
+    paddles: [makePaddle(0), makePaddle(1)],
+    scores: [0, 0],
+    phase: PHASE_WAITING,
+    timer: 0,
+    serveTo: 0,
+    winner: -1,
+    tick: 0,
+    stuckTicks: 0,
+    stuckRefX: TABLE_W / 2,
+    stuckRefY: TABLE_H / 2,
+  };
+  return match;
+}
+
+/** Park the puck at centre and begin the countdown before a serve. */
+export function beginCountdown(match: Match): void {
+  match.puck.x = TABLE_W / 2;
+  match.puck.y = TABLE_H / 2;
+  match.puck.vx = 0;
+  match.puck.vy = 0;
+  match.phase = PHASE_COUNTDOWN;
+  match.timer = COUNTDOWN_TIME;
+  match.stuckTicks = 0;
+  match.stuckRefX = match.puck.x;
+  match.stuckRefY = match.puck.y;
+}
+
+export function resetMatch(match: Match): void {
+  match.scores[0] = 0;
+  match.scores[1] = 0;
+  match.winner = -1;
+  match.serveTo = Math.random() < 0.5 ? 0 : 1;
+  for (const side of [0, 1] as Side[]) {
+    const home = homePosition(side);
+    const p = match.paddles[side];
+    p.x = p.tx = home.x;
+    p.y = p.ty = home.y;
+    p.vx = p.vy = 0;
+  }
+  beginCountdown(match);
+}
+
+/** Record a player's requested paddle position (already in table units). */
+export function setInput(match: Match, side: Side, x: number, y: number): void {
+  const t = clampPaddleTarget(side, x, y);
+  match.paddles[side].tx = t.x;
+  match.paddles[side].ty = t.y;
+}
+
+function serve(match: Match): void {
+  const dir = match.serveTo === 0 ? 1 : -1; // +y is toward side 0
+  const spread = (Math.random() * 2 - 1) * 0.45;
+  match.puck.vx = SERVE_SPEED * spread;
+  match.puck.vy = SERVE_SPEED * dir;
+  match.phase = PHASE_PLAY;
+}
+
+function capSpeed(puck: Puck): void {
+  const s = Math.hypot(puck.vx, puck.vy);
+  if (s > PUCK_MAX_SPEED) {
+    const k = PUCK_MAX_SPEED / s;
+    puck.vx *= k;
+    puck.vy *= k;
+  }
+}
+
+function movePaddles(match: Match, dt: number): void {
+  for (const side of [0, 1] as Side[]) {
+    const p = match.paddles[side];
+    const t = clampPaddleTarget(side, p.tx, p.ty);
+    let dx = t.x - p.x;
+    let dy = t.y - p.y;
+    const d = Math.hypot(dx, dy);
+    const maxStep = PADDLE_MAX_SPEED * dt;
+    if (d > maxStep && d > 0) {
+      dx = (dx / d) * maxStep;
+      dy = (dy / d) * maxStep;
+    }
+    p.vx = dx / dt;
+    p.vy = dy / dt;
+    p.x += dx;
+    p.y += dy;
+  }
+}
+
+/** Resolve a puck/paddle overlap, pushing the puck out and away. */
+function collidePaddle(
+  puck: Puck,
+  paddle: Paddle,
+  side: Side,
+  events: StepEvent[]
+): void {
+  let nx = puck.x - paddle.x;
+  let ny = puck.y - paddle.y;
+  let dist = Math.hypot(nx, ny);
+  const minDist = PUCK_R + PADDLE_R;
+  if (dist >= minDist) return;
+
+  if (dist < 0.0001) {
+    // Perfectly concentric: shove the puck toward the paddle owner's goal.
+    nx = 0;
+    ny = side === 0 ? -1 : 1;
+    dist = 1;
+  } else {
+    nx /= dist;
+    ny /= dist;
+  }
+
+  // Separate first so the next substep starts clean.
+  puck.x = paddle.x + nx * (minDist + 0.01);
+  puck.y = paddle.y + ny * (minDist + 0.01);
+
+  const relVx = puck.vx - paddle.vx;
+  const relVy = puck.vy - paddle.vy;
+  const vn = relVx * nx + relVy * ny;
+  if (vn < 0) {
+    const j = -(1 + PADDLE_BOUNCE) * vn;
+    puck.vx += nx * j;
+    puck.vy += ny * j;
+  }
+
+  // A constant nudge means even a stationary paddle returns the puck, and a
+  // slow, deliberate five-year-old push still does something satisfying.
+  puck.vx += nx * PADDLE_PUSH;
+  puck.vy += ny * PADDLE_PUSH;
+
+  // Guarantee the puck actually leaves the paddle.
+  const outward = puck.vx * nx + puck.vy * ny;
+  if (outward < PUCK_MIN_BOUNCE_SPEED) {
+    const add = PUCK_MIN_BOUNCE_SPEED - outward;
+    puck.vx += nx * add;
+    puck.vy += ny * add;
+  }
+
+  capSpeed(puck);
+  events.push({
+    kind: 'paddle',
+    x: puck.x,
+    y: puck.y,
+    power: clamp(Math.hypot(puck.vx, puck.vy) / PUCK_MAX_SPEED, 0.15, 1),
+    side,
+  });
+}
+
+/**
+ * Advance the simulation by `dt` seconds and return everything worth showing
+ * or hearing. Safe to call with a fixed TICK_DT from either host.
+ */
+export function step(match: Match, dt: number): StepEvent[] {
+  const events: StepEvent[] = [];
+  match.tick++;
+
+  movePaddles(match, dt);
+
+  if (match.phase === PHASE_COUNTDOWN) {
+    match.timer -= dt;
+    if (match.timer <= 0) {
+      match.timer = 0;
+      serve(match);
+    }
+    return events;
+  }
+
+  if (match.phase === PHASE_GOAL) {
+    match.timer -= dt;
+    if (match.timer <= 0) beginCountdown(match);
+    return events;
+  }
+
+  if (match.phase !== PHASE_PLAY) return events;
+
+  const puck = match.puck;
+
+  // Drag.
+  const drag = Math.exp(-PUCK_DRAG * dt);
+  puck.vx *= drag;
+  puck.vy *= drag;
+  capSpeed(puck);
+
+  // Substep so a fast puck can never tunnel through a wall or paddle.
+  const speed = Math.hypot(puck.vx, puck.vy);
+  const steps = clamp(Math.ceil((speed * dt) / (PUCK_R * 0.5)), 1, 10);
+  const sdt = dt / steps;
+
+  for (let i = 0; i < steps; i++) {
+    puck.x += puck.vx * sdt;
+    puck.y += puck.vy * sdt;
+
+    // Side walls.
+    if (puck.x < PUCK_R) {
+      puck.x = PUCK_R;
+      puck.vx = Math.abs(puck.vx) * WALL_BOUNCE;
+      events.push({
+        kind: 'wall',
+        x: puck.x,
+        y: puck.y,
+        power: clamp(Math.abs(puck.vx) / PUCK_MAX_SPEED, 0.1, 1),
+        side: 0,
+      });
+    } else if (puck.x > TABLE_W - PUCK_R) {
+      puck.x = TABLE_W - PUCK_R;
+      puck.vx = -Math.abs(puck.vx) * WALL_BOUNCE;
+      events.push({
+        kind: 'wall',
+        x: puck.x,
+        y: puck.y,
+        power: clamp(Math.abs(puck.vx) / PUCK_MAX_SPEED, 0.1, 1),
+        side: 0,
+      });
+    }
+
+    // End walls / goal mouths.
+    const inMouth = Math.abs(puck.x - TABLE_W / 2) < GOAL_HALF_W - PUCK_R * 0.35;
+    if (puck.y < PUCK_R) {
+      if (inMouth) {
+        scoreGoal(match, 0, events);
+        return events;
+      }
+      puck.y = PUCK_R;
+      puck.vy = Math.abs(puck.vy) * WALL_BOUNCE;
+      events.push({
+        kind: Math.abs(puck.x - TABLE_W / 2) < GOAL_HALF_W + PUCK_R ? 'post' : 'wall',
+        x: puck.x,
+        y: puck.y,
+        power: clamp(Math.abs(puck.vy) / PUCK_MAX_SPEED, 0.1, 1),
+        side: 1,
+      });
+    } else if (puck.y > TABLE_H - PUCK_R) {
+      if (inMouth) {
+        scoreGoal(match, 1, events);
+        return events;
+      }
+      puck.y = TABLE_H - PUCK_R;
+      puck.vy = -Math.abs(puck.vy) * WALL_BOUNCE;
+      events.push({
+        kind: Math.abs(puck.x - TABLE_W / 2) < GOAL_HALF_W + PUCK_R ? 'post' : 'wall',
+        x: puck.x,
+        y: puck.y,
+        power: clamp(Math.abs(puck.vy) / PUCK_MAX_SPEED, 0.1, 1),
+        side: 0,
+      });
+    }
+
+    collidePaddle(puck, match.paddles[0], 0, events);
+    collidePaddle(puck, match.paddles[1], 1, events);
+
+    // Paddles can pin the puck against a wall; keep it inside regardless.
+    puck.x = clamp(puck.x, PUCK_R, TABLE_W - PUCK_R);
+    puck.y = clamp(puck.y, PUCK_R, TABLE_H - PUCK_R);
+  }
+
+  // Deadlock watchdog — see STUCK_TICKS.
+  if (Math.hypot(puck.x - match.stuckRefX, puck.y - match.stuckRefY) > STUCK_DISTANCE) {
+    match.stuckRefX = puck.x;
+    match.stuckRefY = puck.y;
+    match.stuckTicks = 0;
+  } else if (++match.stuckTicks >= STUCK_TICKS) {
+    unstick(match, events);
+  }
+
+  return events;
+}
+
+/**
+ * Free a puck that has stopped moving. If a paddle is pinning it, slide it
+ * *around* the paddle — the way out of a corner is along the wall, not
+ * through the thing holding it there.
+ */
+function unstick(match: Match, events: StepEvent[]): void {
+  const puck = match.puck;
+  match.stuckTicks = 0;
+
+  let nearest: Paddle | null = null;
+  let nearestDist = Infinity;
+  for (const side of [0, 1] as Side[]) {
+    const p = match.paddles[side];
+    const d = Math.hypot(puck.x - p.x, puck.y - p.y);
+    if (d < nearestDist) {
+      nearestDist = d;
+      nearest = p;
+    }
+  }
+
+  const toCentreX = TABLE_W / 2 - puck.x;
+  const toCentreY = TABLE_H / 2 - puck.y;
+  let ex: number;
+  let ey: number;
+
+  if (nearest && nearestDist > 0.001 && nearestDist < (PUCK_R + PADDLE_R) * 1.5) {
+    // Escape along the tangent, choosing whichever way around the paddle
+    // heads for open table.
+    const nx = (puck.x - nearest.x) / nearestDist;
+    const ny = (puck.y - nearest.y) / nearestDist;
+    const dir = -ny * toCentreX + nx * toCentreY >= 0 ? 1 : -1;
+    ex = -ny * dir;
+    ey = nx * dir;
+  } else {
+    const d = Math.hypot(toCentreX, toCentreY) || 1;
+    ex = toCentreX / d;
+    ey = toCentreY / d;
+  }
+
+  const clearance = (PUCK_R + PADDLE_R) * 1.5;
+  puck.x = clamp(puck.x + ex * clearance, PUCK_R, TABLE_W - PUCK_R);
+  puck.y = clamp(puck.y + ey * clearance, PUCK_R, TABLE_H - PUCK_R);
+  puck.vx = ex * SERVE_SPEED * 1.4;
+  puck.vy = ey * SERVE_SPEED * 1.4;
+  match.stuckRefX = puck.x;
+  match.stuckRefY = puck.y;
+
+  events.push({ kind: 'wall', x: puck.x, y: puck.y, power: 0.45, side: 0 });
+}
+
+function scoreGoal(match: Match, scorer: Side, events: StepEvent[]): void {
+  match.scores[scorer]++;
+  events.push({
+    kind: 'goal',
+    x: match.puck.x,
+    y: scorer === 0 ? 0 : TABLE_H,
+    power: 1,
+    side: scorer,
+  });
+
+  match.puck.x = TABLE_W / 2;
+  match.puck.y = TABLE_H / 2;
+  match.puck.vx = 0;
+  match.puck.vy = 0;
+  // The player who conceded gets the next serve coming toward them.
+  match.serveTo = (scorer === 0 ? 1 : 0) as Side;
+
+  if (match.scores[scorer] >= TARGET_SCORE) {
+    match.phase = PHASE_OVER;
+    match.winner = scorer;
+    match.timer = 0;
+    events.push({ kind: 'win', x: TABLE_W / 2, y: TABLE_H / 2, power: 1, side: scorer });
+  } else {
+    match.phase = PHASE_GOAL;
+    match.timer = GOAL_PAUSE;
+  }
+}
+
+// --- Wire format -----------------------------------------------------------
+// Snapshots go out 30x a second, so they are packed into a flat number array
+// rather than an object with keys.
+
+export type Snapshot = number[];
+
+const r2 = (n: number): number => Math.round(n * 100) / 100;
+
+export function encodeSnapshot(match: Match): Snapshot {
+  return [
+    match.tick,
+    r2(match.puck.x),
+    r2(match.puck.y),
+    r2(match.puck.vx),
+    r2(match.puck.vy),
+    r2(match.paddles[0].x),
+    r2(match.paddles[0].y),
+    r2(match.paddles[1].x),
+    r2(match.paddles[1].y),
+    match.scores[0],
+    match.scores[1],
+    match.phase,
+    r2(match.timer),
+    match.winner,
+  ];
+}
+
+export function decodeSnapshot(s: Snapshot): Match {
+  return {
+    tick: s[0],
+    puck: { x: s[1], y: s[2], vx: s[3], vy: s[4] },
+    paddles: [
+      { x: s[5], y: s[6], vx: 0, vy: 0, tx: s[5], ty: s[6] },
+      { x: s[7], y: s[8], vx: 0, vy: 0, tx: s[7], ty: s[8] },
+    ],
+    scores: [s[9], s[10]],
+    phase: s[11] as Phase,
+    timer: s[12],
+    winner: s[13] as Side | -1,
+    // These only matter to whoever is running the simulation, so they stay
+    // off the wire; clients never read them.
+    serveTo: 0,
+    stuckTicks: 0,
+    stuckRefX: s[1],
+    stuckRefY: s[2],
+  };
+}
+
+// --- Room codes ------------------------------------------------------------
+// No I/O/0/1 — an eight-year-old has to read these out loud to a five-year-old.
+
+export const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+export const CODE_LENGTH = 4;
+
+export function isValidCode(code: string): boolean {
+  if (code.length !== CODE_LENGTH) return false;
+  for (const ch of code) if (!CODE_ALPHABET.includes(ch)) return false;
+  return true;
+}
+
+export function randomCode(): string {
+  let out = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    out += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+  }
+  return out;
+}

--- a/games/air-hockey/src/style.css
+++ b/games/air-hockey/src/style.css
@@ -1,0 +1,343 @@
+:root {
+  --bg: #04060f;
+  --cyan: #3fe8ff;
+  --pink: #ff4f9d;
+  --ink: #eaf1ff;
+  --muted: #93a7d6;
+  --panel: rgba(9, 15, 38, 0.82);
+  --font: system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font);
+  /* The table is dragged with a finger; never let the page scroll or zoom. */
+  touch-action: none;
+  overscroll-behavior: none;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#app {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+#app canvas {
+  display: block;
+  touch-action: none;
+}
+
+/* --- Floating in-game controls --- */
+
+#hud {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: max(10px, env(safe-area-inset-top)) 12px 0;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.chip {
+  pointer-events: auto;
+  border: 1px solid rgba(120, 160, 255, 0.28);
+  background: rgba(8, 14, 34, 0.7);
+  color: var(--muted);
+  font: 600 14px/1 var(--font);
+  padding: 9px 13px;
+  border-radius: 999px;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  transition: color 0.15s, border-color 0.15s, transform 0.1s;
+}
+
+.chip:hover {
+  color: var(--ink);
+  border-color: rgba(120, 160, 255, 0.55);
+}
+
+.chip:active {
+  transform: scale(0.94);
+}
+
+.chip-quiet {
+  cursor: default;
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}
+
+/* --- Overlay screens --- */
+
+#overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 30;
+  pointer-events: none;
+}
+
+#overlay:has(.screen:not(.hidden):not(.screen-bottom)) {
+  background: radial-gradient(circle at 50% 40%, rgba(12, 22, 60, 0.86), rgba(4, 6, 15, 0.96));
+  backdrop-filter: blur(3px);
+}
+
+.screen {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 28px 24px;
+  width: min(92vw, 420px);
+  text-align: center;
+  animation: rise 0.32s cubic-bezier(0.2, 0.9, 0.3, 1.3) both;
+}
+
+/* End-of-match and waiting panels sit low so the table stays visible. */
+.screen-bottom {
+  position: fixed;
+  left: 50%;
+  bottom: max(18px, env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  background: var(--panel);
+  border: 1px solid rgba(120, 160, 255, 0.24);
+  border-radius: 22px;
+  backdrop-filter: blur(10px);
+  padding: 20px;
+  width: min(92vw, 340px);
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.96);
+  }
+}
+
+.screen-bottom {
+  animation: riseCentered 0.32s cubic-bezier(0.2, 0.9, 0.3, 1.3) both;
+}
+
+@keyframes riseCentered {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 18px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+.hidden {
+  display: none !important;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(40px, 12vw, 62px);
+  font-weight: 800;
+  letter-spacing: 3px;
+  line-height: 0.95;
+  color: var(--cyan);
+  text-shadow: 0 0 26px rgba(63, 232, 255, 0.55);
+}
+
+.title span {
+  display: block;
+  color: var(--pink);
+  text-shadow: 0 0 26px rgba(255, 79, 157, 0.5);
+}
+
+.heading {
+  margin: 0;
+  font-size: clamp(24px, 7vw, 32px);
+  font-weight: 800;
+  letter-spacing: 1px;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 16px;
+  font-weight: 600;
+  min-height: 1.2em;
+}
+
+.hint {
+  margin: 4px 0 0;
+  color: #6d80ad;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 34ch;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.btn {
+  font: 700 17px/1 var(--font);
+  padding: 16px 20px;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  color: #04060f;
+  transition: transform 0.12s cubic-bezier(0.2, 0.9, 0.3, 1.4), filter 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.btn:hover {
+  filter: brightness(1.1);
+}
+
+.btn:active {
+  transform: scale(0.96);
+}
+
+.btn-icon {
+  font-size: 20px;
+}
+
+.btn-primary {
+  background: linear-gradient(180deg, #6df3ff, #12b6d8);
+  box-shadow: 0 8px 26px rgba(63, 232, 255, 0.3);
+}
+
+.btn-secondary {
+  background: linear-gradient(180deg, #ff7ab8, #e02a7c);
+  color: #22030f;
+  box-shadow: 0 8px 26px rgba(255, 79, 157, 0.28);
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: rgba(120, 160, 255, 0.3);
+  color: var(--muted);
+  font-size: 15px;
+  padding: 12px 18px;
+  box-shadow: none;
+}
+
+.btn-ghost:hover {
+  color: var(--ink);
+}
+
+/* --- Difficulty --- */
+
+.difficulty {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.diff {
+  flex: 1;
+  font: 600 14px/1 var(--font);
+  padding: 11px 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(120, 160, 255, 0.25);
+  background: rgba(12, 20, 48, 0.6);
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.diff.is-active {
+  border-color: var(--cyan);
+  color: #04060f;
+  background: var(--cyan);
+  font-weight: 800;
+}
+
+/* --- Room code --- */
+
+.code {
+  font: 800 clamp(46px, 15vw, 72px) / 1 var(--font);
+  letter-spacing: 12px;
+  text-indent: 12px;
+  color: var(--cyan);
+  background: rgba(8, 16, 42, 0.8);
+  border: 2px dashed rgba(63, 232, 255, 0.45);
+  border-radius: 18px;
+  padding: 16px 20px;
+  text-shadow: 0 0 24px rgba(63, 232, 255, 0.5);
+}
+
+.code-input {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.code-box {
+  width: 58px;
+  height: 72px;
+  text-align: center;
+  font: 800 34px/1 var(--font);
+  color: var(--cyan);
+  background: rgba(8, 16, 42, 0.85);
+  border: 2px solid rgba(120, 160, 255, 0.3);
+  border-radius: 14px;
+  text-transform: uppercase;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.code-box:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 4px rgba(63, 232, 255, 0.16);
+}
+
+/* --- Spinner --- */
+
+.spinner {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 4px solid rgba(120, 160, 255, 0.2);
+  border-top-color: var(--cyan);
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .screen,
+  .screen-bottom {
+    animation: none;
+  }
+  .spinner {
+    animation-duration: 2.4s;
+  }
+}

--- a/games/air-hockey/src/ui.ts
+++ b/games/air-hockey/src/ui.ts
@@ -1,0 +1,236 @@
+import type { Difficulty } from './bot';
+import { audio } from './audio';
+import { CODE_ALPHABET, CODE_LENGTH } from './shared/rules';
+
+export type ScreenName =
+  | 'menu'
+  | 'friend'
+  | 'host'
+  | 'join'
+  | 'connecting'
+  | 'error'
+  | 'over'
+  | 'waiting'
+  | 'none';
+
+const SCREENS: Exclude<ScreenName, 'none'>[] = [
+  'menu',
+  'friend',
+  'host',
+  'join',
+  'connecting',
+  'error',
+  'over',
+  'waiting',
+];
+
+function el<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) throw new Error(`missing #${id}`);
+  return node as T;
+}
+
+/** All the DOM chrome around the canvas: menus, room codes, HUD chips. */
+export class Ui {
+  onSolo: ((difficulty: Difficulty) => void) | null = null;
+  onHost: (() => void) | null = null;
+  onJoin: ((code: string) => void) | null = null;
+  onQuit: (() => void) | null = null;
+  onRematch: (() => void) | null = null;
+
+  difficulty: Difficulty = 'normal';
+  private current: ScreenName = 'menu';
+  private readonly codeBoxes: HTMLInputElement[];
+
+  constructor() {
+    this.codeBoxes = Array.from(document.querySelectorAll<HTMLInputElement>('.code-box'));
+
+    el('btn-solo').addEventListener('click', () => {
+      audio.unlock();
+      audio.uiClick();
+      this.onSolo?.(this.difficulty);
+    });
+    el('btn-error-solo').addEventListener('click', () => {
+      audio.uiClick();
+      this.onSolo?.(this.difficulty);
+    });
+
+    for (const btn of document.querySelectorAll<HTMLButtonElement>('.diff')) {
+      btn.addEventListener('click', () => {
+        audio.unlock();
+        audio.uiClick();
+        for (const other of document.querySelectorAll('.diff')) other.classList.remove('is-active');
+        btn.classList.add('is-active');
+        this.difficulty = (btn.dataset.diff as Difficulty) ?? 'normal';
+      });
+    }
+
+    el('btn-friend').addEventListener('click', () => {
+      audio.unlock();
+      audio.uiClick();
+      this.show('friend');
+    });
+    el('btn-host').addEventListener('click', () => {
+      audio.uiClick();
+      this.onHost?.();
+    });
+    el('btn-join').addEventListener('click', () => {
+      audio.uiClick();
+      this.show('join');
+      this.clearCode();
+      this.codeBoxes[0]?.focus();
+    });
+    el('btn-join-go').addEventListener('click', () => this.submitCode());
+    el('btn-again').addEventListener('click', () => {
+      audio.uiClick();
+      this.onRematch?.();
+    });
+    el('btn-quit').addEventListener('click', () => {
+      audio.uiClick();
+      this.onQuit?.();
+    });
+
+    for (const btn of document.querySelectorAll<HTMLButtonElement>('[data-back]')) {
+      btn.addEventListener('click', () => {
+        audio.uiClick();
+        const target = btn.dataset.back as ScreenName;
+        if (target === 'menu') this.onQuit?.();
+        else this.show(target);
+      });
+    }
+
+    const muteBtn = el<HTMLButtonElement>('btn-mute');
+    const syncMute = (): void => {
+      muteBtn.textContent = audio.muted ? '🔇' : '🔊';
+    };
+    muteBtn.addEventListener('click', () => {
+      audio.unlock();
+      audio.setMuted(!audio.muted);
+      syncMute();
+      if (!audio.muted) audio.uiClick();
+    });
+    syncMute();
+
+    el('btn-copy').addEventListener('click', () => {
+      audio.uiClick();
+      void this.copyInviteLink();
+    });
+
+    this.wireCodeBoxes();
+  }
+
+  // --- Screens -------------------------------------------------------------
+
+  show(name: ScreenName): void {
+    this.current = name;
+    for (const s of SCREENS) {
+      el(`screen-${s}`).classList.toggle('hidden', s !== name);
+    }
+    // The in-game chips only make sense once a match is on screen.
+    const inMatch = name === 'none' || name === 'over' || name === 'waiting';
+    el('hud').classList.toggle('hidden', !inMatch);
+  }
+
+  get screen(): ScreenName {
+    return this.current;
+  }
+
+  setHostCode(code: string): void {
+    el('host-code').textContent = code;
+    el('waiting-code').textContent = code;
+  }
+
+  setHostStatus(text: string): void {
+    el('host-status').textContent = text;
+  }
+
+  setConnectingText(text: string): void {
+    el('connecting-text').textContent = text;
+  }
+
+  setError(text: string): void {
+    el('error-text').textContent = text;
+    this.show('error');
+  }
+
+  setOverStatus(text: string): void {
+    el('over-status').textContent = text;
+  }
+
+  setWaitingText(text: string): void {
+    el('waiting-text').textContent = text;
+  }
+
+  setConnectionInfo(text: string): void {
+    el('conn').textContent = text;
+  }
+
+  // --- Room code entry -----------------------------------------------------
+
+  private wireCodeBoxes(): void {
+    this.codeBoxes.forEach((box, i) => {
+      box.addEventListener('input', () => {
+        const ch = box.value.toUpperCase().replace(/[^A-Z0-9]/g, '');
+        box.value = CODE_ALPHABET.includes(ch) ? ch : '';
+        if (box.value && i < this.codeBoxes.length - 1) this.codeBoxes[i + 1].focus();
+        if (box.value && i === this.codeBoxes.length - 1) this.submitCode();
+      });
+      box.addEventListener('keydown', (e) => {
+        if (e.key === 'Backspace' && !box.value && i > 0) {
+          this.codeBoxes[i - 1].focus();
+          this.codeBoxes[i - 1].value = '';
+          e.preventDefault();
+        }
+        if (e.key === 'Enter') this.submitCode();
+      });
+      box.addEventListener('paste', (e) => {
+        const text = e.clipboardData?.getData('text') ?? '';
+        const chars = text.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, CODE_LENGTH);
+        if (!chars) return;
+        e.preventDefault();
+        this.codeBoxes.forEach((b, j) => {
+          b.value = CODE_ALPHABET.includes(chars[j] ?? '') ? chars[j] : '';
+        });
+        if (chars.length === CODE_LENGTH) this.submitCode();
+      });
+    });
+  }
+
+  private clearCode(): void {
+    for (const b of this.codeBoxes) b.value = '';
+  }
+
+  prefillCode(code: string): void {
+    this.codeBoxes.forEach((b, i) => {
+      b.value = code[i] ?? '';
+    });
+  }
+
+  private submitCode(): void {
+    const code = this.codeBoxes.map((b) => b.value).join('');
+    if (code.length !== CODE_LENGTH) {
+      this.codeBoxes.find((b) => !b.value)?.focus();
+      return;
+    }
+    audio.unlock();
+    audio.uiClick();
+    this.onJoin?.(code);
+  }
+
+  private async copyInviteLink(): Promise<void> {
+    const code = el('host-code').textContent ?? '';
+    const url = `${location.origin}${location.pathname}${location.search}#${code}`;
+    const btn = el<HTMLButtonElement>('btn-copy');
+    const original = 'Copy Invite Link';
+    try {
+      await navigator.clipboard.writeText(url);
+      btn.textContent = 'Copied!';
+    } catch {
+      // Clipboard API needs a secure context; fall back to showing the link.
+      btn.textContent = url;
+    }
+    setTimeout(() => {
+      btn.textContent = original;
+    }, 2200);
+  }
+}

--- a/games/air-hockey/src/view.ts
+++ b/games/air-hockey/src/view.ts
@@ -1,0 +1,598 @@
+import {
+  Application,
+  Container,
+  Graphics,
+  Rectangle,
+  Sprite,
+  Text,
+  TextStyle,
+  Texture,
+} from 'pixi.js';
+import { AdvancedBloomFilter } from 'pixi-filters';
+import { Fx } from './fx';
+import {
+  type EventKind,
+  type Phase,
+  type Side,
+  GOAL_HALF_W,
+  PADDLE_R,
+  PHASE_COUNTDOWN,
+  PHASE_GOAL,
+  PHASE_OVER,
+  PHASE_PLAY,
+  PHASE_WAITING,
+  PUCK_R,
+  TABLE_H,
+  TABLE_W,
+  TARGET_SCORE,
+} from './shared/rules';
+
+// --- Layout ---------------------------------------------------------------
+
+/** Pixels per table unit. */
+const S = 5.4;
+const TABLE_PX_W = TABLE_W * S; // 540
+const TABLE_PX_H = TABLE_H * S; // 864
+const MARGIN_X = 30;
+const MARGIN_Y = 58;
+
+export const VIEW_W = TABLE_PX_W + MARGIN_X * 2; // 600
+export const VIEW_H = TABLE_PX_H + MARGIN_Y * 2; // 980
+
+const TX = MARGIN_X;
+const TY = MARGIN_Y;
+
+const TRAIL_LEN = 12;
+/** How far inside the felt the name/pip row sits. */
+const PIP_INSET = 38;
+
+// --- Palette --------------------------------------------------------------
+
+const COL_BG = 0x04060f;
+const COL_FELT = 0x0b1330;
+const COL_FELT_EDGE = 0x142253;
+const COL_YOU = 0x3fe8ff;
+const COL_OPP = 0xff4f9d;
+const COL_PUCK = 0xfff2c4;
+const COL_PUCK_GLOW = 0xffb03a;
+const COL_LINE = 0x4d7cff;
+
+const FONT_STACK = 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif';
+
+export interface RenderState {
+  puck: { x: number; y: number };
+  paddles: [{ x: number; y: number }, { x: number; y: number }];
+  scores: [number, number];
+  phase: Phase;
+  timer: number;
+  winner: number;
+}
+
+/**
+ * Everything on screen is built once and then moved. Rebuilding Pixi Graphics
+ * every frame re-tessellates and re-uploads geometry, which was enough to drop
+ * a software renderer to single-digit fps.
+ */
+export class View {
+  private readonly world = new Container();
+  private readonly bloomLayer = new Container();
+  private readonly staticArt = new Graphics();
+  private readonly flashOverlay = new Graphics();
+  private readonly flashBlob: Sprite;
+  private readonly trailSprites: Sprite[] = [];
+  private readonly trailPoints: { x: number; y: number }[] = [];
+  private readonly paddleNodes: [Container, Container];
+  private readonly puckNode = new Container();
+  private readonly hud = new Container();
+  private readonly bigScore: [Text, Text];
+  private readonly pips: [Graphics, Graphics];
+  private readonly nameText: [Text, Text];
+  private readonly centerText: Text;
+  private readonly centerSub: Text;
+  private readonly softGlow: Texture;
+
+  readonly fx: Fx;
+
+  private mySide: Side = 0;
+  private names: [string, string] = ['You', 'Opponent'];
+  private centerPop = 0;
+  private goalFlash = 0;
+  private goalFlashAtTop = false;
+  private lastPips: [number, number] = [-1, -1];
+
+  constructor(private readonly app: Application) {
+    this.app.stage.addChild(this.world);
+
+    // One soft radial texture, reused for every glow in the scene.
+    const blob = new Graphics();
+    for (let i = 12; i >= 1; i--) {
+      blob.circle(64, 64, (64 * i) / 12).fill({ color: 0xffffff, alpha: 0.055 });
+    }
+    this.softGlow = this.app.renderer.generateTexture({ target: blob, resolution: 1 });
+    blob.destroy();
+
+    this.buildBackground();
+
+    // Full-resolution: the filter renders the whole layer through itself, so
+    // dropping its resolution softens the table lines, not just the glow.
+    this.bloomLayer.filters = [
+      new AdvancedBloomFilter({
+        threshold: 0.4,
+        bloomScale: 1.1,
+        brightness: 1.0,
+        blur: 6,
+        quality: 3,
+      }),
+    ];
+    // Without an explicit area Pixi recomputes filter bounds every frame.
+    this.bloomLayer.filterArea = new Rectangle(0, 0, VIEW_W, VIEW_H);
+    this.world.addChild(this.bloomLayer);
+
+    this.bloomLayer.addChild(this.staticArt);
+
+    // Goal flash: drawn white once, tinted per goal.
+    this.flashOverlay.roundRect(TX, TY, TABLE_PX_W, TABLE_PX_H, 26).fill({ color: 0xffffff });
+    this.flashOverlay.alpha = 0;
+    this.flashBlob = new Sprite(this.softGlow);
+    this.flashBlob.anchor.set(0.5);
+    this.flashBlob.width = GOAL_HALF_W * S * 3.2;
+    this.flashBlob.height = 150;
+    this.flashBlob.blendMode = 'add';
+    this.flashBlob.alpha = 0;
+    this.bloomLayer.addChild(this.flashOverlay, this.flashBlob);
+
+    // Puck trail: pooled sprites rather than a Graphics rebuilt every frame.
+    const trailLayer = new Container();
+    for (let i = 0; i < TRAIL_LEN; i++) {
+      const s = new Sprite(this.softGlow);
+      s.anchor.set(0.5);
+      s.tint = COL_PUCK_GLOW;
+      s.blendMode = 'add';
+      s.visible = false;
+      trailLayer.addChild(s);
+      this.trailSprites.push(s);
+    }
+    this.bloomLayer.addChild(trailLayer);
+
+    this.paddleNodes = [this.buildPaddle(COL_YOU), this.buildPaddle(COL_OPP)];
+    this.buildPuck();
+    this.bloomLayer.addChild(this.paddleNodes[0], this.paddleNodes[1], this.puckNode);
+
+    this.fx = new Fx(this.app.renderer, this.bloomLayer);
+
+    this.drawTable();
+
+    // --- HUD (unfiltered, so text stays crisp) ---
+    this.world.addChild(this.hud);
+
+    const bigStyle = new TextStyle({
+      fontFamily: FONT_STACK,
+      fontSize: 300,
+      fontWeight: '800',
+      fill: 0xffffff,
+    });
+    this.bigScore = [new Text({ text: '0', style: bigStyle }), new Text({ text: '0', style: bigStyle })];
+    for (const t of this.bigScore) {
+      t.anchor.set(0.5);
+      t.alpha = 0.05;
+      this.hud.addChild(t);
+    }
+
+    this.pips = [new Graphics(), new Graphics()];
+    this.hud.addChild(this.pips[0], this.pips[1]);
+
+    // Each label needs its OWN style object: a TextStyle shared between two
+    // Text nodes means recolouring one recolours both.
+    const nameStyle = (fill: number): TextStyle =>
+      new TextStyle({
+        fontFamily: FONT_STACK,
+        fontSize: 20,
+        fontWeight: '700',
+        fill,
+        letterSpacing: 1.5,
+      });
+    this.nameText = [
+      new Text({ text: '', style: nameStyle(COL_YOU) }),
+      new Text({ text: '', style: nameStyle(COL_OPP) }),
+    ];
+    this.nameText[0].anchor.set(0, 0.5);
+    this.nameText[1].anchor.set(0, 0.5);
+    this.hud.addChild(this.nameText[0], this.nameText[1]);
+
+    this.centerText = new Text({
+      text: '',
+      style: new TextStyle({
+        fontFamily: FONT_STACK,
+        fontSize: 96,
+        fontWeight: '800',
+        fill: 0xffffff,
+        align: 'center',
+      }),
+    });
+    this.centerText.anchor.set(0.5);
+    this.centerText.position.set(VIEW_W / 2, VIEW_H / 2 - 24);
+
+    this.centerSub = new Text({
+      text: '',
+      style: new TextStyle({
+        fontFamily: FONT_STACK,
+        fontSize: 26,
+        fontWeight: '600',
+        fill: 0xbcd0ff,
+        align: 'center',
+      }),
+    });
+    this.centerSub.anchor.set(0.5);
+    this.centerSub.position.set(VIEW_W / 2, VIEW_H / 2 + 52);
+    this.hud.addChild(this.centerText, this.centerSub);
+
+    this.layoutHud();
+  }
+
+  // --- Coordinate transform ------------------------------------------------
+
+  /** Table units → screen pixels, flipped so "your" goal is always at the bottom. */
+  private px(x: number, y: number): { x: number; y: number } {
+    const fx = this.mySide === 1 ? TABLE_W - x : x;
+    const fy = this.mySide === 1 ? TABLE_H - y : y;
+    return { x: TX + fx * S, y: TY + fy * S };
+  }
+
+  /** Screen pixels → table units, for pointer input. */
+  toTable(px: number, py: number): { x: number; y: number } {
+    const x = (px - TX) / S;
+    const y = (py - TY) / S;
+    return this.mySide === 1 ? { x: TABLE_W - x, y: TABLE_H - y } : { x, y };
+  }
+
+  setSide(side: Side): void {
+    if (side === this.mySide) return;
+    this.mySide = side;
+    this.trailPoints.length = 0;
+    // Colours are assigned by "is this me", so both paddles need repainting.
+    this.repaintPaddle(this.paddleNodes[0], side === 0 ? COL_YOU : COL_OPP);
+    this.repaintPaddle(this.paddleNodes[1], side === 1 ? COL_YOU : COL_OPP);
+    this.drawTable();
+    this.lastPips = [-1, -1];
+    this.layoutHud();
+  }
+
+  setNames(names: [string, string]): void {
+    this.names = names;
+    this.layoutHud();
+  }
+
+  // --- Built-once nodes ----------------------------------------------------
+
+  private buildPaddle(color: number): Container {
+    const node = new Container();
+    node.addChild(new Graphics());
+    this.repaintPaddle(node, color);
+    return node;
+  }
+
+  private repaintPaddle(node: Container, color: number): void {
+    const g = node.children[0] as Graphics;
+    const r = PADDLE_R * S;
+    g.clear();
+    g.circle(0, 5, r * 0.98).fill({ color: 0x000000, alpha: 0.4 });
+    g.circle(0, 0, r).fill({ color: 0x0a1230, alpha: 0.95 });
+    g.circle(0, 0, r).stroke({ width: 4, color, alpha: 1 });
+    g.circle(0, 0, r * 0.62).stroke({ width: 2, color, alpha: 0.55 });
+    g.circle(0, 0, r * 0.3).fill({ color, alpha: 0.9 });
+    g.circle(-r * 0.28, -r * 0.3, r * 0.16).fill({ color: 0xffffff, alpha: 0.5 });
+  }
+
+  private buildPuck(): void {
+    const r = PUCK_R * S;
+    const glow = new Sprite(this.softGlow);
+    glow.anchor.set(0.5);
+    glow.width = r * 7;
+    glow.height = r * 7;
+    glow.tint = COL_PUCK_GLOW;
+    glow.blendMode = 'add';
+    glow.alpha = 0.75;
+
+    const g = new Graphics();
+    g.circle(0, 4, r).fill({ color: 0x000000, alpha: 0.35 });
+    g.circle(0, 0, r).fill({ color: COL_PUCK });
+    g.circle(0, 0, r).stroke({ width: 2, color: COL_PUCK_GLOW, alpha: 0.9 });
+    g.circle(-r * 0.3, -r * 0.3, r * 0.3).fill({ color: 0xffffff, alpha: 0.85 });
+
+    this.puckNode.addChild(glow, g);
+  }
+
+  // --- Static art ----------------------------------------------------------
+
+  private buildBackground(): void {
+    const bg = new Graphics();
+    bg.rect(0, 0, VIEW_W, VIEW_H).fill({ color: COL_BG });
+    // Faint cabinet grid so the letterboxed area isn't dead space.
+    for (let x = 0; x <= VIEW_W; x += 30) {
+      bg.rect(x, 0, 1, VIEW_H).fill({ color: 0x121a3a, alpha: 0.5 });
+    }
+    for (let y = 0; y <= VIEW_H; y += 30) {
+      bg.rect(0, y, VIEW_W, 1).fill({ color: 0x121a3a, alpha: 0.5 });
+    }
+    this.world.addChild(bg);
+
+    // Ambient pool of light under the table.
+    const halo = new Sprite(this.softGlow);
+    halo.anchor.set(0.5);
+    halo.position.set(VIEW_W / 2, VIEW_H / 2);
+    halo.width = VIEW_W * 1.7;
+    halo.height = VIEW_H * 1.2;
+    halo.tint = 0x1d3a8f;
+    halo.alpha = 0.5;
+    halo.blendMode = 'add';
+    this.world.addChild(halo);
+  }
+
+  private drawTable(): void {
+    const g = this.staticArt;
+    const myColor = COL_YOU;
+    const oppColor = COL_OPP;
+    g.clear();
+
+    // Rail and felt.
+    g.roundRect(TX - 12, TY - 12, TABLE_PX_W + 24, TABLE_PX_H + 24, 34).fill({ color: 0x070c1e });
+    g.roundRect(TX - 12, TY - 12, TABLE_PX_W + 24, TABLE_PX_H + 24, 34).stroke({
+      width: 3,
+      color: 0x2b3f8a,
+      alpha: 0.9,
+    });
+    g.roundRect(TX, TY, TABLE_PX_W, TABLE_PX_H, 26).fill({ color: COL_FELT });
+    g.roundRect(TX, TY, TABLE_PX_W, TABLE_PX_H, 26).stroke({ width: 2.5, color: COL_FELT_EDGE });
+
+    // Half tints: your end reads cool, theirs warm.
+    g.rect(TX, TY + TABLE_PX_H / 2, TABLE_PX_W, TABLE_PX_H / 2 - 4).fill({
+      color: myColor,
+      alpha: 0.035,
+    });
+    g.rect(TX, TY + 4, TABLE_PX_W, TABLE_PX_H / 2 - 4).fill({ color: oppColor, alpha: 0.03 });
+
+    // Centre line (dashed) + circle.
+    const midY = TY + TABLE_PX_H / 2;
+    for (let x = TX + 10; x < TX + TABLE_PX_W - 10; x += 26) {
+      g.rect(x, midY - 1.5, 15, 3).fill({ color: COL_LINE, alpha: 0.45 });
+    }
+    g.circle(VIEW_W / 2, midY, 17 * S).stroke({ width: 3, color: COL_LINE, alpha: 0.4 });
+    g.circle(VIEW_W / 2, midY, 3.2 * S).stroke({ width: 2, color: COL_LINE, alpha: 0.55 });
+    g.circle(VIEW_W / 2, midY, 5).fill({ color: COL_LINE, alpha: 0.6 });
+
+    // Goal creases. arc() draws a line from wherever the path currently is to
+    // the arc's start point, so each one needs an explicit moveTo first.
+    const creaseR = 27 * S;
+    g.moveTo(VIEW_W / 2 + creaseR, TY)
+      .arc(VIEW_W / 2, TY, creaseR, 0, Math.PI)
+      .stroke({ width: 2.5, color: oppColor, alpha: 0.32 });
+    g.moveTo(VIEW_W / 2 - creaseR, TY + TABLE_PX_H)
+      .arc(VIEW_W / 2, TY + TABLE_PX_H, creaseR, Math.PI, Math.PI * 2)
+      .stroke({ width: 2.5, color: myColor, alpha: 0.32 });
+
+    // Goal mouths.
+    const mouthW = GOAL_HALF_W * 2 * S;
+    const mouthX = VIEW_W / 2 - mouthW / 2;
+    g.rect(mouthX, TY - 7, mouthW, 8).fill({ color: oppColor });
+    g.rect(mouthX, TY + TABLE_PX_H - 1, mouthW, 8).fill({ color: myColor });
+    for (const gx of [mouthX, mouthX + mouthW]) {
+      g.circle(gx, TY, 5).fill({ color: 0xffffff, alpha: 0.85 });
+      g.circle(gx, TY + TABLE_PX_H, 5).fill({ color: 0xffffff, alpha: 0.85 });
+    }
+
+    // Corner accents.
+    const corner = 30;
+    for (const [cx, cy, sx, sy] of [
+      [TX, TY, 1, 1],
+      [TX + TABLE_PX_W, TY, -1, 1],
+      [TX, TY + TABLE_PX_H, 1, -1],
+      [TX + TABLE_PX_W, TY + TABLE_PX_H, -1, -1],
+    ] as const) {
+      g.moveTo(cx + sx * 14, cy + sy * corner)
+        .lineTo(cx + sx * 14, cy + sy * 22)
+        .lineTo(cx + sx * 22, cy + sy * 14)
+        .lineTo(cx + sx * corner, cy + sy * 14)
+        .stroke({ width: 2, color: 0x3b56b8, alpha: 0.55 });
+    }
+  }
+
+  private layoutHud(): void {
+    const midY = TY + TABLE_PX_H / 2;
+    // Index 0 is always the bottom half on screen = the local player.
+    this.bigScore[0].position.set(VIEW_W / 2, midY + TABLE_PX_H / 4);
+    this.bigScore[1].position.set(VIEW_W / 2, midY - TABLE_PX_H / 4);
+
+    // Names and pips sit just inside the felt. The margin strip above the
+    // table is where the floating DOM chips live, and they would collide at
+    // some window sizes.
+    this.nameText[0].position.set(TX + 18, TY + TABLE_PX_H - PIP_INSET);
+    this.nameText[1].position.set(TX + 18, TY + PIP_INSET);
+    this.setText(this.nameText[0], this.names[this.mySide] || 'You');
+    this.setText(this.nameText[1], this.names[this.mySide === 0 ? 1 : 0] || 'Waiting…');
+  }
+
+  private setText(node: Text, value: string): void {
+    if (node.text !== value) node.text = value;
+  }
+
+  private drawPips(target: Graphics, score: number, color: number, y: number): void {
+    target.clear();
+    const r = 6;
+    const gap = 19;
+    const startX = TX + TABLE_PX_W - (TARGET_SCORE - 1) * gap - 22;
+    for (let i = 0; i < TARGET_SCORE; i++) {
+      const x = startX + i * gap;
+      if (i < score) target.circle(x, y, r).fill({ color });
+      else target.circle(x, y, r).stroke({ width: 2, color, alpha: 0.35 });
+    }
+  }
+
+  // --- Per-event feedback --------------------------------------------------
+
+  /** Turn a rules event into particles, shake and a flash. */
+  impact(kind: EventKind, x: number, y: number, power: number, side: Side): void {
+    const p = this.px(x, y);
+    switch (kind) {
+      case 'paddle': {
+        const color = side === this.mySide ? COL_YOU : COL_OPP;
+        this.fx.burst(p.x, p.y, 8 + Math.round(power * 14), {
+          color,
+          speed: 120 + power * 340,
+          life: 0.34,
+          size: 5,
+        });
+        this.fx.addShake(0.06 + power * 0.14);
+        break;
+      }
+      case 'wall': {
+        this.fx.burst(p.x, p.y, 4 + Math.round(power * 7), {
+          color: 0x9fc6ff,
+          speed: 90 + power * 220,
+          life: 0.26,
+          size: 4,
+        });
+        this.fx.addShake(power * 0.06);
+        break;
+      }
+      case 'post': {
+        this.fx.burst(p.x, p.y, 14, { color: 0xffffff, speed: 260, life: 0.4, size: 5 });
+        this.fx.addShake(0.12 + power * 0.1);
+        break;
+      }
+      case 'goal': {
+        const scoredByMe = side === this.mySide;
+        const color = scoredByMe ? COL_YOU : COL_OPP;
+        this.fx.burst(p.x, p.y, 80, { color, speed: 520, life: 0.9, size: 8 });
+        this.fx.burst(p.x, p.y, 36, { color: 0xffffff, speed: 300, life: 0.6, size: 6 });
+        this.fx.addShake(0.55);
+        this.goalFlash = 1;
+        // A goal I scored lands in the far net, at the top of my screen.
+        this.goalFlashAtTop = scoredByMe;
+        this.flashOverlay.tint = color;
+        this.flashBlob.tint = color;
+        this.flashBlob.position.set(VIEW_W / 2, this.goalFlashAtTop ? TY : TY + TABLE_PX_H);
+        this.centerPop = 1;
+        break;
+      }
+      case 'win':
+        this.fx.addShake(0.7);
+        break;
+    }
+  }
+
+  celebrate(won: boolean): void {
+    const color = won ? COL_YOU : COL_OPP;
+    for (let i = 0; i < 6; i++) {
+      const x = TX + 40 + Math.random() * (TABLE_PX_W - 80);
+      const y = TY + 60 + Math.random() * (TABLE_PX_H - 120);
+      this.fx.burst(x, y, 24, { color, speed: 340, life: 1.1, size: 7 });
+    }
+  }
+
+  // --- Frame ---------------------------------------------------------------
+
+  render(state: RenderState, dt: number): void {
+    this.fx.update(dt);
+    this.world.position.set(this.fx.shakeX, this.fx.shakeY);
+
+    // Scores, indexed by screen position rather than side id.
+    const mine = state.scores[this.mySide];
+    const theirs = state.scores[this.mySide === 0 ? 1 : 0];
+    this.setText(this.bigScore[0], String(mine));
+    this.setText(this.bigScore[1], String(theirs));
+    if (this.lastPips[0] !== mine || this.lastPips[1] !== theirs) {
+      this.lastPips = [mine, theirs];
+      this.drawPips(this.pips[0], mine, COL_YOU, TY + TABLE_PX_H - PIP_INSET);
+      this.drawPips(this.pips[1], theirs, COL_OPP, TY + PIP_INSET);
+    }
+
+    // Puck.
+    const puckPx = this.px(state.puck.x, state.puck.y);
+    const puckVisible = state.phase !== PHASE_WAITING;
+    this.puckNode.visible = puckVisible;
+    this.puckNode.position.set(puckPx.x, puckPx.y);
+
+    // Trail.
+    if (state.phase === PHASE_PLAY) {
+      this.trailPoints.unshift({ x: puckPx.x, y: puckPx.y });
+      if (this.trailPoints.length > TRAIL_LEN) this.trailPoints.pop();
+    } else {
+      this.trailPoints.length = 0;
+    }
+    for (let i = 0; i < TRAIL_LEN; i++) {
+      const s = this.trailSprites[i];
+      const pt = this.trailPoints[i];
+      if (!pt) {
+        s.visible = false;
+        continue;
+      }
+      const k = 1 - i / TRAIL_LEN;
+      s.visible = true;
+      s.position.set(pt.x, pt.y);
+      const size = PUCK_R * S * (1.6 + k * 2.4);
+      s.width = size;
+      s.height = size;
+      s.alpha = k * 0.38;
+    }
+
+    // Paddles.
+    for (const side of [0, 1] as Side[]) {
+      const p = this.px(state.paddles[side].x, state.paddles[side].y);
+      this.paddleNodes[side].position.set(p.x, p.y);
+    }
+
+    // Goal flash.
+    if (this.goalFlash > 0) {
+      this.goalFlash = Math.max(0, this.goalFlash - dt * 1.4);
+      const eased = this.goalFlash * this.goalFlash;
+      this.flashOverlay.alpha = eased * 0.12;
+      this.flashBlob.alpha = eased * 0.55;
+    } else if (this.flashOverlay.alpha !== 0) {
+      this.flashOverlay.alpha = 0;
+      this.flashBlob.alpha = 0;
+    }
+
+    this.updateCenterMessage(state, dt);
+  }
+
+  private updateCenterMessage(state: RenderState, dt: number): void {
+    let text = '';
+    let sub = '';
+
+    switch (state.phase) {
+      case PHASE_COUNTDOWN: {
+        const n = Math.ceil(state.timer);
+        text = n <= 0 ? 'GO!' : String(n);
+        break;
+      }
+      case PHASE_GOAL:
+        text = 'GOAL!';
+        sub = this.goalFlashAtTop ? 'Nice shot!' : '';
+        break;
+      case PHASE_OVER:
+        text = state.winner === this.mySide ? 'YOU WIN!' : 'YOU LOSE';
+        sub = `${state.scores[this.mySide]} – ${state.scores[this.mySide === 0 ? 1 : 0]}`;
+        break;
+      default:
+        text = '';
+    }
+
+    if (this.centerText.text !== text) {
+      this.centerText.text = text;
+      if (text) this.centerPop = 1;
+    }
+    this.setText(this.centerSub, sub);
+
+    // The puck sits at centre during the countdown, so lift the digit clear
+    // of it rather than stacking the two on top of each other.
+    this.centerText.y = state.phase === PHASE_COUNTDOWN ? VIEW_H / 2 - 158 : VIEW_H / 2 - 24;
+
+    // outBack-ish pop on every change.
+    this.centerPop = Math.max(0, this.centerPop - dt * 3.2);
+    const t = 1 - this.centerPop;
+    const overshoot = 1 + 0.45 * Math.sin(Math.PI * Math.min(1, t) ** 0.7) * this.centerPop;
+    this.centerText.scale.set(overshoot);
+    this.centerText.alpha = this.centerText.text ? Math.min(1, 0.3 + t * 1.6) : 0;
+    this.centerSub.alpha = this.centerSub.text ? Math.min(1, t * 1.6) : 0;
+  }
+}

--- a/games/air-hockey/src/vite-env.d.ts
+++ b/games/air-hockey/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /**
+   * Base URL of the multiplayer Worker, baked in at build time by CI.
+   * Optional — the client falls back to `<origin>/mp`, and to solo play if
+   * neither is reachable.
+   */
+  readonly VITE_MP_SERVER_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/games/air-hockey/test/smoke.mjs
+++ b/games/air-hockey/test/smoke.mjs
@@ -1,0 +1,225 @@
+/**
+ * Smoke test for Air Hockey.
+ *
+ * Serves the BUILT dist under a subpath (like production) and drives two
+ * independent browser contexts through a real networked match against a
+ * locally running `wrangler dev`, then plays a solo match against the bot.
+ *
+ * Usage:
+ *   node test/smoke.mjs                 # expects wrangler dev on :8787
+ *   MP=ws://127.0.0.1:8787 node test/smoke.mjs
+ */
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.join(HERE, '..', 'dist');
+const SHOTS = path.join(HERE, 'screenshots');
+const PORT = 8099;
+const BASE = `http://127.0.0.1:${PORT}/air-hockey/`;
+const MP = process.env.MP || 'ws://127.0.0.1:8787';
+
+const TYPES = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.json': 'application/json',
+  '.png': 'image/png',
+};
+
+function serve() {
+  const server = http.createServer((req, res) => {
+    let rel = decodeURIComponent(req.url.split('?')[0]);
+    if (!rel.startsWith('/air-hockey/')) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    rel = rel.slice('/air-hockey/'.length) || 'index.html';
+    const file = path.join(DIST, rel);
+    if (!file.startsWith(DIST) || !fs.existsSync(file) || fs.statSync(file).isDirectory()) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': TYPES[path.extname(file)] || 'application/octet-stream' });
+    fs.createReadStream(file).pipe(res);
+  });
+  return new Promise((resolve) => server.listen(PORT, '127.0.0.1', () => resolve(server)));
+}
+
+const problems = [];
+
+function watch(page, label) {
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') problems.push(`[${label}] console: ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => problems.push(`[${label}] pageerror: ${err.message}`));
+  page.on('requestfailed', (req) => {
+    problems.push(`[${label}] failed request: ${req.url()} (${req.failure()?.errorText})`);
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Drive a paddle like a player would: sit behind the puck when it is in your
+ * half so contact sends it upfield, otherwise fall back to defend. Chasing
+ * directly onto the puck just smothers it.
+ */
+const STRIKE = () => {
+  const g = window.__game;
+  const s = g.snapshot;
+  if (!s) return;
+  const mine = g.side;
+  const own = mine === 0;
+  const inMyHalf = own ? s.puck.y > 160 * 0.45 : s.puck.y < 160 * 0.55;
+  if (inMyHalf) {
+    g.setTarget(s.puck.x, s.puck.y + (own ? 11 : -11));
+  } else {
+    g.setTarget(50, own ? 140 : 20);
+  }
+};
+
+async function waitFor(page, predicate, { timeout = 30000, label = 'condition' } = {}) {
+  const started = Date.now();
+  while (Date.now() - started < timeout) {
+    if (await page.evaluate(predicate)) return;
+    await sleep(150);
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function main() {
+  fs.mkdirSync(SHOTS, { recursive: true });
+  const server = await serve();
+  // The preinstalled Chromium may not match this playwright build's expected
+  // revision, so point at it directly.
+  const executablePath = fs.existsSync('/opt/pw-browsers/chromium')
+    ? '/opt/pw-browsers/chromium'
+    : undefined;
+  const browser = await chromium.launch({ executablePath });
+
+  try {
+    // --- Solo vs bot -------------------------------------------------------
+    const solo = await browser.newContext({ viewport: { width: 820, height: 1000 } });
+    const p1 = await solo.newPage();
+    watch(p1, 'solo');
+    await p1.goto(BASE, { waitUntil: 'networkidle' });
+    await p1.waitForFunction(() => !!window.__game);
+    await sleep(600);
+    await p1.screenshot({ path: path.join(SHOTS, '01-menu.png') });
+
+    await p1.click('#btn-solo');
+    await waitFor(p1, () => window.__game.mode === 'solo', { label: 'solo mode' });
+    await waitFor(p1, () => window.__game.snapshot?.phase === 2, { label: 'solo play phase' });
+
+    // Play properly so the bot actually has a game to play.
+    const chase = setInterval(() => {
+      p1.evaluate(STRIKE).catch(() => {});
+    }, 60);
+
+    await waitFor(p1, () => (window.__game.snapshot?.scores ?? [0, 0]).some((v) => v > 0), {
+      timeout: 60000,
+      label: 'a goal in solo mode',
+    });
+    await p1.screenshot({ path: path.join(SHOTS, '02-solo-play.png') });
+    clearInterval(chase);
+    const soloScores = await p1.evaluate(() => window.__game.snapshot.scores);
+    console.log(`✓ solo: scored ${soloScores.join('–')}`);
+    await solo.close();
+
+    // --- Two browsers, one table -------------------------------------------
+    const ctxA = await browser.newContext({ viewport: { width: 820, height: 1000 } });
+    const ctxB = await browser.newContext({ viewport: { width: 820, height: 1000 } });
+    const a = await ctxA.newPage();
+    const b = await ctxB.newPage();
+    watch(a, 'A');
+    watch(b, 'B');
+
+    const url = `${BASE}?server=${encodeURIComponent(MP)}`;
+    await a.goto(url, { waitUntil: 'networkidle' });
+    await a.waitForFunction(() => !!window.__game);
+
+    await a.click('#btn-friend');
+    await a.click('#btn-host');
+    await waitFor(a, () => window.__game.code?.length === 4, { label: 'a room code' });
+    const code = await a.evaluate(() => window.__game.code);
+    console.log(`✓ hosted room ${code}`);
+    await sleep(600); // let the panel finish its entrance animation
+    await a.screenshot({ path: path.join(SHOTS, '03-room-code.png') });
+
+    // Second device follows the invite link.
+    await b.goto(`${url}#${code}`, { waitUntil: 'networkidle' });
+    await b.waitForFunction(() => !!window.__game);
+
+    await waitFor(a, () => window.__game.opponentPresent === true, { label: 'player 2 to join' });
+    await waitFor(b, () => window.__game.opponentPresent === true, { label: 'player 1 visible' });
+    const sides = [await a.evaluate(() => window.__game.side), await b.evaluate(() => window.__game.side)];
+    if (sides[0] === sides[1]) throw new Error(`both players got side ${sides[0]}`);
+    console.log(`✓ both connected (sides ${sides.join(' and ')})`);
+
+    await waitFor(a, () => window.__game.snapshot?.phase === 2, { label: 'match to start' });
+
+    // A plays properly; B parks in a corner so goals actually happen.
+    const drive = setInterval(() => {
+      a.evaluate(STRIKE).catch(() => {});
+      // B hides in a corner so goals actually happen.
+      b.evaluate(() => window.__game.setTarget(12, 12)).catch(() => {});
+    }, 60);
+
+    await waitFor(a, () => (window.__game.snapshot?.scores ?? [0, 0]).some((v) => v > 0), {
+      timeout: 60000,
+      label: 'a goal in the networked match',
+    });
+
+    // Both browsers must agree about the score — that is the whole point.
+    await sleep(600);
+    const scoreA = await a.evaluate(() => window.__game.snapshot.scores);
+    const scoreB = await b.evaluate(() => window.__game.snapshot.scores);
+    if (scoreA.join() !== scoreB.join()) {
+      throw new Error(`scores disagree: A saw ${scoreA} but B saw ${scoreB}`);
+    }
+    console.log(`✓ both browsers agree on the score: ${scoreA.join('–')}`);
+
+    // Puck positions should agree closely too (allowing for interpolation).
+    const puckA = await a.evaluate(() => window.__game.snapshot.puck);
+    const puckB = await b.evaluate(() => window.__game.snapshot.puck);
+    const drift = Math.hypot(puckA.x - puckB.x, puckA.y - puckB.y);
+    if (drift > 25) throw new Error(`puck drifted ${drift.toFixed(1)} units between browsers`);
+    console.log(`✓ puck agrees within ${drift.toFixed(1)} units`);
+
+    await a.screenshot({ path: path.join(SHOTS, '04-online-a.png') });
+    await b.screenshot({ path: path.join(SHOTS, '05-online-b.png') });
+    clearInterval(drive);
+
+    // --- Disconnect handling -----------------------------------------------
+    await ctxB.close();
+    await waitFor(a, () => window.__game.opponentPresent === false, {
+      label: 'A to notice B left',
+    });
+    console.log('✓ remaining player sees the disconnect');
+    await sleep(600);
+    await a.screenshot({ path: path.join(SHOTS, '06-opponent-left.png') });
+
+    await ctxA.close();
+
+    if (problems.length) {
+      console.error('\n✗ page problems:\n' + problems.join('\n'));
+      process.exitCode = 1;
+    } else {
+      console.log('\n✓ no console errors, no failed requests');
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('✗ ' + err.message);
+  console.error(problems.join('\n'));
+  process.exit(1);
+});

--- a/games/air-hockey/tsconfig.json
+++ b/games/air-hockey/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/games/air-hockey/vite.config.ts
+++ b/games/air-hockey/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  // Required for serving from a subdirectory (/air-hockey/) on games.ross.dev.
+  base: './',
+  build: {
+    target: 'es2020',
+    chunkSizeWarningLimit: 2000,
+  },
+});

--- a/landing/icons/air-hockey.svg
+++ b/landing/icons/air-hockey.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <defs>
+    <linearGradient id="ahFelt" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#16224f"/>
+      <stop offset="50%" stop-color="#0d1637"/>
+      <stop offset="100%" stop-color="#101c46"/>
+    </linearGradient>
+    <radialGradient id="ahPuck" cx="36%" cy="32%" r="72%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="55%" stop-color="#fff2c4"/>
+      <stop offset="100%" stop-color="#e79a22"/>
+    </radialGradient>
+    <radialGradient id="ahCyan" cx="38%" cy="34%" r="70%">
+      <stop offset="0%" stop-color="#b7f6ff"/>
+      <stop offset="60%" stop-color="#3fe8ff"/>
+      <stop offset="100%" stop-color="#1183a3"/>
+    </radialGradient>
+    <radialGradient id="ahPink" cx="38%" cy="34%" r="70%">
+      <stop offset="0%" stop-color="#ffc2dd"/>
+      <stop offset="60%" stop-color="#ff4f9d"/>
+      <stop offset="100%" stop-color="#a3175c"/>
+    </radialGradient>
+  </defs>
+
+  <!-- cabinet -->
+  <rect width="100" height="100" rx="12" fill="#04060f"/>
+
+  <!-- table -->
+  <rect x="18" y="8" width="64" height="84" rx="10" fill="url(#ahFelt)"/>
+  <rect x="18" y="8" width="64" height="84" rx="10" fill="none" stroke="#2b3f8a" stroke-width="2"/>
+
+  <!-- centre line + circle -->
+  <g stroke="#4d7cff" stroke-linecap="round">
+    <path d="M21 50 H79" stroke-width="2" stroke-dasharray="5 4" opacity="0.6"/>
+    <circle cx="50" cy="50" r="13" fill="none" stroke-width="2" opacity="0.45"/>
+  </g>
+  <circle cx="50" cy="50" r="2" fill="#4d7cff" opacity="0.7"/>
+
+  <!-- goal creases -->
+  <path d="M30 8 A20 20 0 0 0 70 8" fill="none" stroke="#ff4f9d" stroke-width="1.8" opacity="0.4"/>
+  <path d="M30 92 A20 20 0 0 1 70 92" fill="none" stroke="#3fe8ff" stroke-width="1.8" opacity="0.4"/>
+
+  <!-- goal mouths -->
+  <rect x="36" y="6.5" width="28" height="4" rx="2" fill="#ff4f9d"/>
+  <rect x="36" y="89.5" width="28" height="4" rx="2" fill="#3fe8ff"/>
+
+  <!-- far paddle (pink) -->
+  <circle cx="43" cy="26" r="9" fill="#0a1230"/>
+  <circle cx="43" cy="26" r="9" fill="none" stroke="#ff4f9d" stroke-width="3"/>
+  <circle cx="43" cy="26" r="3.4" fill="url(#ahPink)"/>
+
+  <!-- near paddle (cyan) -->
+  <circle cx="57" cy="74" r="9" fill="#0a1230"/>
+  <circle cx="57" cy="74" r="9" fill="none" stroke="#3fe8ff" stroke-width="3"/>
+  <circle cx="57" cy="74" r="3.4" fill="url(#ahCyan)"/>
+
+  <!-- puck with motion trail -->
+  <circle cx="46" cy="60" r="3.6" fill="#ffb03a" opacity="0.16"/>
+  <circle cx="48" cy="56" r="4.4" fill="#ffb03a" opacity="0.26"/>
+  <circle cx="50" cy="51" r="5.6" fill="url(#ahPuck)"/>
+  <circle cx="48.4" cy="49.4" r="1.7" fill="#ffffff" opacity="0.9"/>
+</svg>

--- a/landing/index.html
+++ b/landing/index.html
@@ -36,6 +36,14 @@
   <main>
     <div class="game-grid">
 
+      <a href="./air-hockey/" class="game-card">
+        <div class="game-icon">
+          <img src="icons/air-hockey.svg" alt="">
+        </div>
+        <h2>Air Hockey</h2>
+        <p>Two players, two devices, one neon table</p>
+      </a>
+
       <a href="./asteroid-dodger/" class="game-card">
         <div class="game-icon">
           <img src="icons/asteroid-dodger.svg" alt="">

--- a/multiplayer-server/README.md
+++ b/multiplayer-server/README.md
@@ -78,6 +78,17 @@ overwrite each other. Deploy manually with:
 npx wrangler deploy --env preview
 ```
 
+### Changing either URL
+
+The URL is baked into the bundle at build time, so changing `MP_SERVER_URL` or
+`MP_PREVIEW_SERVER_URL` means the game has to be rebuilt. `scripts/build-all.js`
+knows this — `BUILD_ENV` lists `VITE_MP_SERVER_URL` as part of Air Hockey's
+cache key, so a changed URL invalidates that game (and only that game).
+
+Without it the build cache would see byte-identical source files, skip the
+game, and go on shipping the old URL indefinitely. If you ever add another
+build-time variable to a game, add it to `BUILD_ENV` too.
+
 [preview-urls]: https://developers.cloudflare.com/workers/configuration/previews/
 
 ## Pointing the game at it

--- a/multiplayer-server/README.md
+++ b/multiplayer-server/README.md
@@ -1,0 +1,70 @@
+# Air Hockey multiplayer server
+
+A Cloudflare Worker + Durable Object that hosts real-time air hockey matches
+for `games/air-hockey`. One Durable Object per room code; it is the authority
+for the puck, so the two browsers can never disagree.
+
+- **60Hz** physics tick, **30Hz** snapshot broadcast.
+- Simulation is shared verbatim with the client:
+  [`games/air-hockey/src/shared/rules.ts`](../games/air-hockey/src/shared/rules.ts).
+  The client uses the same file for solo-vs-bot play, so the puck behaves
+  identically whether you're playing a human or the computer.
+- Paddle input is clamped server-side to the sending player's own half, so a
+  tampered client can't reach across the table.
+
+## Endpoints
+
+| Route | Purpose |
+|-------|---------|
+| `GET /health` | Liveness probe — returns `{"ok":true}` |
+| `GET /room/<CODE>?name=<name>` | WebSocket upgrade into a room (4-char code) |
+
+A `/mp` path prefix is stripped if present, so the same code works whether the
+Worker is on `*.workers.dev` or mounted at `games.ross.dev/mp/*`.
+
+## Local development
+
+```bash
+cd multiplayer-server
+npm install
+npm run dev          # wrangler dev on http://localhost:8787
+```
+
+Then run the game against it:
+
+```bash
+cd ../games/air-hockey
+npm install
+npm run dev
+# open http://localhost:5173/?server=ws://localhost:8787
+```
+
+## Deploying
+
+CI (`.github/workflows/deploy.yml`) deploys this on every push to `main` using
+the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets. Manually:
+
+```bash
+npx wrangler deploy
+```
+
+## Pointing the game at it
+
+The client resolves its server URL in this order:
+
+1. `?server=` query parameter (handy for testing)
+2. `VITE_MP_SERVER_URL`, baked in at build time
+3. `<same origin>/mp` as a fallback
+
+So there are two supported setups:
+
+- **Simplest:** deploy, note the `https://air-hockey-server.<your-subdomain>.workers.dev`
+  URL wrangler prints, and set it as a GitHub Actions repository **variable**
+  named `MP_SERVER_URL`. The deploy workflow passes it through to the build.
+- **Zero-config:** uncomment the `[[routes]]` block in `wrangler.toml` to mount
+  the Worker at `games.ross.dev/mp/*`. The client then finds it on its own with
+  no variable set. This needs the API token to have `Zone:Edit` on `ross.dev`.
+
+If neither is configured, the game still works — it falls back to solo-vs-bot
+and shows a clear "two-player mode isn't set up yet" message rather than
+appearing broken.

--- a/multiplayer-server/README.md
+++ b/multiplayer-server/README.md
@@ -42,11 +42,43 @@ npm run dev
 ## Deploying
 
 CI (`.github/workflows/deploy.yml`) deploys this on every push to `main` using
-the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets. Manually:
+the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets. That
+token needs **`Workers Scripts: Edit`** — a different permission from the
+`Cloudflare Pages: Edit` the site deploy uses. Without it the Worker job fails
+while the site still ships green, so the Worker silently freezes at its last
+version while `rules.ts` moves on in the game. That drift shows up as desyncs
+rather than as a clear error, so it is worth confirming.
+
+The workflow has a `workflow_dispatch` trigger for exactly that check — run it
+from the Actions tab and watch **Deploy multiplayer server** go green without
+having to push to `main`. Manually, from here:
 
 ```bash
 npx wrangler deploy
 ```
+
+### Preview environment
+
+PR previews get their own Worker, `air-hockey-server-preview`, deployed by
+`.github/workflows/preview.yml`. Preview builds are pointed at it via the
+`MP_PREVIEW_SERVER_URL` repository variable, so a client built from a PR can
+never join a room on the production server — which matters because the server
+is authoritative and `rules.ts` is shared verbatim, so a simulation change
+under review would otherwise land a differently-behaved client in a live match.
+
+Cloudflare's built-in preview URLs cannot cover this: they are [not generated
+for Workers that implement a Durable Object][preview-urls], and DO lifecycle
+changes only apply through `wrangler deploy`. A separate Worker is the only
+option.
+
+Every PR shares that one preview Worker, so two Air Hockey PRs open at once
+overwrite each other. Deploy manually with:
+
+```bash
+npx wrangler deploy --env preview
+```
+
+[preview-urls]: https://developers.cloudflare.com/workers/configuration/previews/
 
 ## Pointing the game at it
 

--- a/multiplayer-server/package-lock.json
+++ b/multiplayer-server/package-lock.json
@@ -1,0 +1,1562 @@
+{
+  "name": "air-hockey-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "air-hockey-server",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1",
+        "typescript": "^5.6.0",
+        "wrangler": "^4.33.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260730.1.tgz",
+      "integrity": "sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260730.1.tgz",
+      "integrity": "sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260730.1.tgz",
+      "integrity": "sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260730.1.tgz",
+      "integrity": "sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260801.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260801.1.tgz",
+      "integrity": "sha512-XCv5xWi47WQOK0LpLa6997Mrpz8Ct+nZmp/M5Xp8Z4BFsarf7nYjkznGOcOoYK5m1GfbMFEEuQ2OIZnbIWoe9A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.22.tgz",
+      "integrity": "sha512-XEUMtc8zk6oKA5pyl+KqmVfk66ep978VbK+nBw5HfgThGhqYiokP0QYrnHY4U2A2vbzr7cUS1IeXt/poO3KA9g==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260730.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260730.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260730.1.tgz",
+      "integrity": "sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260730.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260730.1",
+        "@cloudflare/workerd-linux-64": "1.20260730.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260730.1",
+        "@cloudflare/workerd-windows-64": "1.20260730.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260730.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260730.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260730.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/multiplayer-server/package.json
+++ b/multiplayer-server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "air-hockey-server",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260730.1",
+    "typescript": "^5.6.0",
+    "wrangler": "^4.33.0"
+  }
+}

--- a/multiplayer-server/src/index.ts
+++ b/multiplayer-server/src/index.ts
@@ -1,0 +1,285 @@
+/**
+ * Air Hockey multiplayer server.
+ *
+ * A single Cloudflare Worker that upgrades WebSocket connections and hands
+ * them to a Durable Object, one per room code. The Durable Object is the
+ * authority: it runs the physics at 60Hz and broadcasts snapshots at 30Hz, so
+ * the two browsers can never disagree about where the puck is.
+ *
+ * The simulation itself lives in the game directory and is shared verbatim
+ * with the client, which uses it for solo-vs-bot play:
+ *   games/air-hockey/src/shared/rules.ts
+ */
+
+import {
+  type Match,
+  type Side,
+  type Snapshot,
+  type StepEvent,
+  PHASE_OVER,
+  PHASE_WAITING,
+  TICK_DT,
+  TICK_RATE,
+  beginCountdown,
+  createMatch,
+  encodeSnapshot,
+  isValidCode,
+  resetMatch,
+  setInput,
+  step,
+} from '../../games/air-hockey/src/shared/rules';
+
+export interface Env {
+  ROOMS: DurableObjectNamespace;
+}
+
+const SNAPSHOT_EVERY = 2; // ticks — 60Hz simulation, 30Hz on the wire
+const EMPTY_ROOM_GRACE_MS = 60_000;
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    // Tolerate being mounted under a path prefix (e.g. a games.ross.dev/mp/*
+    // Worker route) as well as at the root of a workers.dev subdomain.
+    const path = url.pathname.replace(/^\/mp(?=\/|$)/, '') || '/';
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS });
+    }
+
+    if (path === '/' || path === '/health') {
+      return Response.json({ ok: true, service: 'air-hockey' }, { headers: CORS });
+    }
+
+    const roomMatch = path.match(/^\/room\/([A-Za-z0-9]+)$/);
+    if (roomMatch) {
+      const code = roomMatch[1].toUpperCase();
+      if (!isValidCode(code)) {
+        return new Response('Bad room code', { status: 400, headers: CORS });
+      }
+      if (request.headers.get('Upgrade') !== 'websocket') {
+        return new Response('Expected WebSocket upgrade', { status: 426, headers: CORS });
+      }
+      const id = env.ROOMS.idFromName(code);
+      return env.ROOMS.get(id).fetch(request);
+    }
+
+    return new Response('Not found', { status: 404, headers: CORS });
+  },
+};
+
+interface Player {
+  socket: WebSocket;
+  side: Side;
+  name: string;
+  wantsRematch: boolean;
+}
+
+export class AirHockeyRoom {
+  private players: Player[] = [];
+  private match: Match = createMatch();
+  private loop: ReturnType<typeof setInterval> | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private sinceSnapshot = 0;
+  private pendingEvents: StepEvent[] = [];
+
+  constructor(
+    private readonly ctx: DurableObjectState,
+    private readonly env: Env
+  ) {
+    void this.ctx;
+    void this.env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const name = (url.searchParams.get('name') || 'Player').slice(0, 12);
+
+    if (this.players.length >= 2) {
+      // Tell the joiner why rather than dropping them silently.
+      const pair = new WebSocketPair();
+      const [client, server] = [pair[0], pair[1]];
+      server.accept();
+      server.send(JSON.stringify({ t: 'full' }));
+      server.close(4001, 'Room is full');
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = [pair[0], pair[1]];
+    server.accept();
+
+    const takenSides = new Set(this.players.map((p) => p.side));
+    const side: Side = takenSides.has(0) ? 1 : 0;
+    const player: Player = { socket: server, side, name, wantsRematch: false };
+    this.players.push(player);
+
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+
+    server.addEventListener('message', (event: MessageEvent) => {
+      this.onMessage(player, event.data);
+    });
+    const drop = (): void => this.onLeave(player);
+    server.addEventListener('close', drop);
+    server.addEventListener('error', drop);
+
+    this.send(player, {
+      t: 'joined',
+      side,
+      code: url.pathname.split('/').pop()?.toUpperCase() ?? '',
+      tickRate: TICK_RATE,
+    });
+    this.broadcastRoster();
+
+    // Two players present and nothing in flight: start a fresh match.
+    if (this.players.length === 2 && this.match.phase === PHASE_WAITING) {
+      resetMatch(this.match);
+      this.broadcastRoster();
+    }
+    this.startLoop();
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private onMessage(player: Player, raw: unknown): void {
+    if (typeof raw !== 'string') return;
+    let msg: { t?: string; x?: number; y?: number; id?: number };
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    switch (msg.t) {
+      case 'input': {
+        if (typeof msg.x !== 'number' || typeof msg.y !== 'number') return;
+        if (!Number.isFinite(msg.x) || !Number.isFinite(msg.y)) return;
+        // setInput clamps to the player's own half, so a tampered client
+        // still cannot reach across the table.
+        setInput(this.match, player.side, msg.x, msg.y);
+        break;
+      }
+      case 'rematch': {
+        player.wantsRematch = true;
+        if (this.match.phase !== PHASE_OVER) break;
+        const others = this.players.filter((p) => p !== player);
+        if (others.length === 0 || others.every((p) => p.wantsRematch)) {
+          for (const p of this.players) p.wantsRematch = false;
+          resetMatch(this.match);
+        }
+        this.broadcastRoster();
+        break;
+      }
+      case 'ping': {
+        this.send(player, { t: 'pong', id: msg.id });
+        break;
+      }
+    }
+  }
+
+  private onLeave(player: Player): void {
+    const idx = this.players.indexOf(player);
+    if (idx === -1) return;
+    this.players.splice(idx, 1);
+
+    if (this.players.length < 2 && this.match.phase !== PHASE_OVER) {
+      // Freeze the match — scores are kept so a dropped player can rejoin
+      // the same room code and carry on.
+      this.match.phase = PHASE_WAITING;
+      this.match.timer = 0;
+    }
+    this.broadcastRoster();
+
+    if (this.players.length === 0) {
+      this.stopLoop();
+      this.idleTimer = setTimeout(() => {
+        this.match = createMatch();
+        this.idleTimer = null;
+      }, EMPTY_ROOM_GRACE_MS);
+    }
+  }
+
+  private startLoop(): void {
+    if (this.loop !== null) return;
+    this.loop = setInterval(() => this.tick(), 1000 / TICK_RATE);
+  }
+
+  private stopLoop(): void {
+    if (this.loop === null) return;
+    clearInterval(this.loop);
+    this.loop = null;
+  }
+
+  private tick(): void {
+    if (this.players.length === 0) {
+      this.stopLoop();
+      return;
+    }
+
+    if (this.players.length === 2 && this.match.phase === PHASE_WAITING) {
+      beginCountdown(this.match);
+    }
+
+    const events = step(this.match, TICK_DT);
+    if (events.length) this.pendingEvents.push(...events);
+
+    if (++this.sinceSnapshot >= SNAPSHOT_EVERY) {
+      this.sinceSnapshot = 0;
+      const payload: { t: 'snap'; s: Snapshot; e?: StepEvent[] } = {
+        t: 'snap',
+        s: encodeSnapshot(this.match),
+      };
+      if (this.pendingEvents.length) {
+        payload.e = this.pendingEvents;
+        this.pendingEvents = [];
+      }
+      this.broadcast(payload);
+    }
+  }
+
+  private broadcastRoster(): void {
+    const names: [string, string] = ['', ''];
+    const present: [boolean, boolean] = [false, false];
+    for (const p of this.players) {
+      names[p.side] = p.name;
+      present[p.side] = true;
+    }
+    this.broadcast({
+      t: 'roster',
+      names,
+      present,
+      rematch: [
+        this.players.find((p) => p.side === 0)?.wantsRematch ?? false,
+        this.players.find((p) => p.side === 1)?.wantsRematch ?? false,
+      ],
+    });
+  }
+
+  private send(player: Player, msg: unknown): void {
+    try {
+      player.socket.send(JSON.stringify(msg));
+    } catch {
+      // Socket already gone; the close handler will clean it up.
+    }
+  }
+
+  private broadcast(msg: unknown): void {
+    const data = JSON.stringify(msg);
+    for (const p of this.players) {
+      try {
+        p.socket.send(data);
+      } catch {
+        // Ignore; close handler removes it.
+      }
+    }
+  }
+}

--- a/multiplayer-server/tsconfig.json
+++ b/multiplayer-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src", "../games/air-hockey/src/shared"]
+}

--- a/multiplayer-server/wrangler.toml
+++ b/multiplayer-server/wrangler.toml
@@ -1,0 +1,22 @@
+name = "air-hockey-server"
+main = "src/index.ts"
+compatibility_date = "2025-09-01"
+workers_dev = true
+
+[[durable_objects.bindings]]
+name = "ROOMS"
+class_name = "AirHockeyRoom"
+
+# SQLite-backed Durable Objects are the ones available on the Workers free
+# plan. The room keeps its state in memory anyway — a match that outlives the
+# two browsers playing it is not worth persisting.
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["AirHockeyRoom"]
+
+# Optional: serve the game server from the same origin as the site, which lets
+# the client skip configuration entirely (it falls back to `<origin>/mp`).
+# Requires the Cloudflare API token to have Zone:Edit on ross.dev.
+# [[routes]]
+# pattern = "games.ross.dev/mp/*"
+# zone_name = "ross.dev"

--- a/multiplayer-server/wrangler.toml
+++ b/multiplayer-server/wrangler.toml
@@ -20,3 +20,30 @@ new_sqlite_classes = ["AirHockeyRoom"]
 # [[routes]]
 # pattern = "games.ross.dev/mp/*"
 # zone_name = "ross.dev"
+
+# A second Worker that PR previews talk to, so a preview client never joins a
+# room on the production server. That matters more than it sounds: the server
+# is authoritative and `rules.ts` is shared verbatim with the client, so a PR
+# that changes the simulation would otherwise put a differently-behaved client
+# into a live match with someone actually playing.
+#
+# Cloudflare's built-in preview URLs cannot do this job — they are not
+# generated for Workers that implement a Durable Object, and DO lifecycle
+# changes only apply via `wrangler deploy`. Hence a whole separate Worker.
+#
+# All PRs share this one Worker, so two Air Hockey PRs open at once overwrite
+# each other's deploy. Per-PR Workers would need teardown on close; not worth
+# the machinery here.
+# `name` is deliberately not set here. Wrangler names an environment's Worker
+# `<top-level-name>-<environment-name>`, which is already exactly
+# `air-hockey-server-preview`. Setting it explicitly would rely on override
+# semantics the docs do not actually specify.
+[env.preview]
+
+# `migrations` is inheritable and carries over on its own, but
+# `durable_objects` is NOT — it has to be repeated per environment. Leave this
+# out and the preview Worker still deploys clean, then fails at runtime the
+# moment someone tries to host a room, because ROOMS is not bound.
+[[env.preview.durable_objects.bindings]]
+name = "ROOMS"
+class_name = "AirHockeyRoom"

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -14,6 +14,15 @@ const games = require('./games-list.js');
 
 const staticGames = ['connect-four', 'hangman', 'number-line-monster', 'ojoj', 'sudoku', 'tic-tac-toe'];
 
+// Build-time environment variables that get baked into a game's bundle, and so
+// have to be part of its cache key. Hashing source files alone cannot see
+// them: point MP_SERVER_URL at a different Worker and every file on disk is
+// byte-identical, so the game would be skipped as cached and keep shipping the
+// old URL — silently, and for as long as nobody happens to edit the game.
+const BUILD_ENV = {
+  'air-hockey': ['VITE_MP_SERVER_URL'],
+};
+
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.DS_Store', '.wrangler', '.playwright-mcp', '.claude']);
 
 const forceRebuild = process.argv.includes('--force');
@@ -53,13 +62,19 @@ function collectFiles(dir) {
   return results;
 }
 
-function computeDirectoryHash(dir) {
+function computeDirectoryHash(dir, envVars = []) {
   const files = collectFiles(dir).sort();
   const hash = crypto.createHash('sha256');
   for (const file of files) {
     const rel = path.relative(dir, file);
     hash.update(rel);
     hash.update(fs.readFileSync(file));
+  }
+  // Unset and empty are deliberately the same input here: both produce a build
+  // with no URL baked in, so they should not force a rebuild of each other.
+  for (const name of envVars) {
+    hash.update(name);
+    hash.update(process.env[name] || '');
   }
   return hash.digest('hex');
 }
@@ -188,7 +203,7 @@ for (const game of games) {
   const gameDist = path.join(DIST_DIR, game);
   const isStatic = staticGames.includes(game);
 
-  const sourceHash = computeDirectoryHash(gameDir);
+  const sourceHash = computeDirectoryHash(gameDir, BUILD_ENV[game]);
   const depsHash = isStatic ? null : computeDepsHash(gameDir);
   const cached = manifest.entries[game];
 

--- a/scripts/games-list.js
+++ b/scripts/games-list.js
@@ -1,6 +1,7 @@
 // The games that get built into dist/. Single source of truth for the build
 // and the offline check — add a new game's slug here.
 module.exports = [
+  'air-hockey',
   'asteroid-dodger',
   'balloon-pop-blitz',
   'comet-dash',


### PR DESCRIPTION
Two browsers on two devices share one table. Adds the arcade's first
multiplayer game plus the server infrastructure to support future ones.

multiplayer-server/: a Cloudflare Worker with one Durable Object per room
code. It is authoritative — 60Hz physics, 30Hz snapshots over WebSockets —
so the two browsers can never disagree about the score, and paddle input is
clamped server-side to the sender's own half. Deployed by its own CI job so a
multiplayer failure can't block the rest of the arcade from shipping.

games/air-hockey/: PixiJS v8 + TS + Vite. The simulation in src/shared/rules.ts
is shared verbatim with the Worker, and solo-vs-bot runs it in-page behind the
same Transport interface, so the game loop never branches on mode. Clients
smooth the 30Hz feed with buffered interpolation while drawing their own paddle
from local prediction, and impact effects are queued to fire on the frame they
belong to.

The game degrades gracefully: if no multiplayer server is configured or
reachable, it says so plainly and offers the bot instead of looking broken.
See multiplayer-server/README.md for the one-time setup to enable two-player.

Verified with a Playwright smoke test that drives two independent browser
contexts through a real match against a local wrangler dev, asserting both
browsers agree on score and puck position and that disconnects are noticed.

Notable fix found while testing: a paddle held against a wall could pin the
puck permanently, because the wall clamp and the paddle's outward push
cancelled each other every tick. rules.ts now detects a puck that has stopped
travelling and slides it back out around the paddle.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JCoEudUZrEU7Y4KdiKqdXT