### PR TITLE
Fix service worker breaking every page load (production is affected)

### DIFF
--- a/.claude/commands/new-game.md
+++ b/.claude/commands/new-game.md
@@ -35,7 +35,7 @@ Reference implementations: `games/comet-dash` (Babylon), `games/robot-rally` (Th
 
 ## 5. Register the game
 
-1. Add the slug to the `games` array in `scripts/build-all.js` (and `staticGames` only if it has no build step).
+1. Add the slug to `scripts/games-list.js` (and the `staticGames` array in `scripts/build-all.js` only if it has no build step).
 2. Add a card to `landing/index.html` in the `.game-grid` (alphabetical-ish position).
 3. Create a real scene-depicting SVG icon at `landing/icons/$ARGUMENTS.svg` (100×100, rounded-rect background, style-matched to the game — look at existing icons; no generic gamepad placeholders).
 4. Add a row to the Game Inventory table in the root `CLAUDE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Use the `/new-game` slash command:
 Or manually:
 1. Create `games/<name>/` with your game code
 2. If using Vite, set `base: './'` in vite.config (required for subdirectory serving)
-3. Add the game slug to the `games` array in `scripts/build-all.js`
+3. Add the game slug to `scripts/games-list.js`
 4. Add a card to `landing/index.html`
 5. Add an SVG icon to `landing/icons/<name>.svg`
 
@@ -99,6 +99,24 @@ first visit.
 **Installing**: Mac — Safari's *Add to Dock*, or Chrome's install button.
 iPad — Share → *Add to Home Screen*. On iOS this step matters: Safari evicts
 site data for tabs unused for 7 days, but home screen web apps keep theirs.
+
+**Verifying**: `npm run build && npm run verify:offline` precaches, kills the
+server, and loads every game from cache alone. Run it after touching anything
+in the offline path. It serves through `scripts/pages-server.js`, which
+imitates Cloudflare Pages — `npx serve dist` does **not**, and the difference
+hides real bugs (see below).
+
+**Safari gotchas** — both already handled, but easy to reintroduce:
+
+- *Redirects.* Safari refuses a navigation response whose `redirected` flag is
+  set ("Response served by service worker has redirections"). Pages
+  308-redirects `/index.html` → `/`, so pages are cached under their directory
+  URL (`/phase-10/`), and anything cached is rebuilt to clear the flag. Chromium
+  serves redirected responses happily, so only the assertion in
+  `verify-offline.js` catches this — not a passing page load.
+- *Range requests.* Safari asks for audio with a `Range` header and rejects the
+  plain 200 the Cache API returns, so the worker slices cached media into real
+  206 responses.
 
 Two rules to keep offline working when adding a game:
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dev": "node scripts/build-all.js && npx serve dist",
     "serve": "npx serve dist",
     "build:force": "node scripts/build-all.js --force",
+    "serve:pages": "node scripts/pages-server.js",
+    "verify:offline": "node scripts/verify-offline.js",
     "clean": "rm -rf dist"
   }
 }

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -10,30 +10,7 @@ const LANDING_DIR = path.join(ROOT, 'landing');
 const MANIFEST_PATH = path.join(ROOT, '.build-cache.json');
 const SCRIPT_PATH = __filename;
 
-const games = [
-  'asteroid-dodger',
-  'balloon-pop-blitz',
-  'comet-dash',
-  'connect-four',
-  'grand-hotel-tycoon',
-  'guess-the-drawing',
-  'hangman',
-  'hanyverse',
-  'kpop-rythm-tap',
-  'neon-bricks',
-  'number-line-monster',
-  'ojoj',
-  'pet-care-game',
-  'phase-10',
-  'pinball',
-  'robot-rally',
-  'sir-name-alot',
-  'skee-ball',
-  'sudoku',
-  'tic-tac-toe',
-  'treasure-hunt-island',
-  'unicorn-dragon',
-];
+const games = require('./games-list.js');
 
 const staticGames = ['connect-four', 'hangman', 'number-line-monster', 'ojoj', 'sudoku', 'tic-tac-toe'];
 
@@ -133,7 +110,13 @@ function buildServiceWorker() {
     .filter((file) => !notPrecacheable.has(path.basename(file)) && !file.endsWith('.map'))
     .sort();
 
+  const template = fs.readFileSync(path.join(__dirname, 'sw-template.js'), 'utf8');
+
   const hash = crypto.createHash('sha256');
+  // The worker's own logic is part of the version: changing how things are
+  // cached has to retire the cache built by the previous logic, not reuse it.
+  hash.update(template);
+
   const assets = [];
   const shell = [];
 
@@ -143,7 +126,12 @@ function buildServiceWorker() {
     hash.update(rel);
     hash.update(contents);
 
-    const url = `./${rel}`;
+    // Cache pages under the URL the browser actually navigates to. Cloudflare
+    // Pages 308-redirects /index.html to /, and Safari refuses to serve a
+    // response carrying a redirect to a navigation, so fetching by the
+    // directory name is what keeps the cached copy usable offline.
+    const url =
+      path.basename(rel) === 'index.html' ? `./${rel.slice(0, -'index.html'.length)}` : `./${rel}`;
     assets.push([url, contents.length]);
     // Anything outside a game directory is the landing page — cached during
     // install so the arcade opens immediately, before the library finishes.
@@ -159,7 +147,6 @@ function buildServiceWorker() {
     __SHELL__: JSON.stringify(shell),
   };
 
-  const template = fs.readFileSync(path.join(__dirname, 'sw-template.js'), 'utf8');
   let source = template;
   for (const [token, value] of Object.entries(replacements)) {
     if (!source.includes(token)) {

--- a/scripts/games-list.js
+++ b/scripts/games-list.js
@@ -1,0 +1,26 @@
+// The games that get built into dist/. Single source of truth for the build
+// and the offline check — add a new game's slug here.
+module.exports = [
+  'asteroid-dodger',
+  'balloon-pop-blitz',
+  'comet-dash',
+  'connect-four',
+  'grand-hotel-tycoon',
+  'guess-the-drawing',
+  'hangman',
+  'hanyverse',
+  'kpop-rythm-tap',
+  'neon-bricks',
+  'number-line-monster',
+  'ojoj',
+  'pet-care-game',
+  'phase-10',
+  'pinball',
+  'robot-rally',
+  'sir-name-alot',
+  'skee-ball',
+  'sudoku',
+  'tic-tac-toe',
+  'treasure-hunt-island',
+  'unicorn-dragon',
+];

--- a/scripts/pages-server.js
+++ b/scripts/pages-server.js
@@ -1,0 +1,83 @@
+/**
+ * Static server that mimics Cloudflare Pages' URL normalization — notably the
+ * 308 from /index.html to /, which is what broke the service worker in Safari
+ * and which plain `http-server` does not do.
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = require('path').join(__dirname, '..', 'dist');
+const PORT = Number(process.env.PORT || 8124);
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json',
+  '.webmanifest': 'application/manifest+json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.woff2': 'font/woff2',
+  '.glb': 'model/gltf-binary',
+  '.gltf': 'model/gltf+json',
+  '.map': 'application/json',
+};
+
+http
+  .createServer((req, res) => {
+    const url = new URL(req.url, `http://localhost:${PORT}`);
+    let pathname = decodeURIComponent(url.pathname);
+
+    // Pages canonicalizes /index.html -> / (this is the 308 that bit us).
+    if (pathname.endsWith('/index.html')) {
+      res.writeHead(308, { Location: pathname.slice(0, -'index.html'.length) + url.search });
+      return res.end();
+    }
+
+    let filePath = path.join(ROOT, pathname);
+
+    // ...and /dir -> /dir/
+    if (!pathname.endsWith('/') && fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+      res.writeHead(308, { Location: `${pathname}/${url.search}` });
+      return res.end();
+    }
+
+    if (pathname.endsWith('/')) filePath = path.join(filePath, 'index.html');
+
+    if (!filePath.startsWith(ROOT) || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      return res.end('Not found');
+    }
+
+    const size = fs.statSync(filePath).size;
+    const type = TYPES[path.extname(filePath)] || 'application/octet-stream';
+    const range = /^bytes=(\d*)-(\d*)$/.exec(req.headers.range || '');
+
+    if (range) {
+      const start = range[1] === '' ? size - Number(range[2]) : Number(range[1]);
+      const end = range[2] === '' || range[1] === '' ? size - 1 : Number(range[2]);
+      res.writeHead(206, {
+        'Content-Type': type,
+        'Content-Range': `bytes ${start}-${end}/${size}`,
+        'Content-Length': end - start + 1,
+        'Accept-Ranges': 'bytes',
+        'Cache-Control': 'no-store',
+      });
+      return fs.createReadStream(filePath, { start, end }).pipe(res);
+    }
+
+    res.writeHead(200, {
+      'Content-Type': type,
+      'Content-Length': size,
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'no-store',
+    });
+    fs.createReadStream(filePath).pipe(res);
+  })
+  .listen(PORT, () => console.log(`pages-like server on http://localhost:${PORT}`));

--- a/scripts/sw-template.js
+++ b/scripts/sw-template.js
@@ -51,7 +51,10 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     (async () => {
       const cache = await caches.open(CACHE);
-      await Promise.all(SHELL.map((path) => fetchAndCache(cache, path)));
+      // Tolerate individual failures. A worker that cannot finish installing
+      // can never replace a broken one already serving this site, and the
+      // background precache refetches whatever is missing anyway.
+      await Promise.allSettled(SHELL.map((path) => fetchAndCache(cache, path)));
       await self.skipWaiting();
     })()
   );
@@ -220,7 +223,10 @@ self.addEventListener('fetch', (event) => {
       }
 
       if (cached) {
-        return request.headers.has('range') ? rangeResponse(request, cached) : cached;
+        if (request.headers.has('range')) return rangeResponse(request, cached);
+        // Never hand a navigation a redirected response: the browser rejects
+        // it outright and the page dies. Free when the flag is not set.
+        return request.mode === 'navigate' ? withoutRedirectFlag(cached) : cached;
       }
 
       try {

--- a/scripts/sw-template.js
+++ b/scripts/sw-template.js
@@ -24,12 +24,36 @@ const SHELL = __SHELL__;
 const ASSET_PATHS = ASSETS.map(([path]) => path);
 const TOTAL_BYTES = ASSETS.reduce((sum, [, bytes]) => sum + bytes, 0);
 
+/**
+ * Safari rejects a navigation response whose `redirected` flag is set, with
+ * "Response served by service worker has redirections" — so a redirect that
+ * was followed on the way into the cache breaks the page offline. Rebuilding
+ * the response drops the flag. Cache.addAll gives no chance to do this, which
+ * is why precaching is written out by hand below.
+ */
+async function withoutRedirectFlag(response) {
+  if (!response.redirected) return response;
+  return new Response(await response.blob(), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+async function fetchAndCache(cache, path) {
+  // reload bypasses the HTTP cache so a precache always stores fresh bytes.
+  const response = await fetch(new Request(path, { cache: 'reload' }));
+  if (!response.ok) throw new Error(`HTTP ${response.status} for ${path}`);
+  await cache.put(path, await withoutRedirectFlag(response));
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches
-      .open(CACHE)
-      .then((cache) => cache.addAll(SHELL))
-      .then(() => self.skipWaiting())
+    (async () => {
+      const cache = await caches.open(CACHE);
+      await Promise.all(SHELL.map((path) => fetchAndCache(cache, path)));
+      await self.skipWaiting();
+    })()
   );
 });
 
@@ -91,10 +115,7 @@ async function precacheAll() {
     while (index < pending.length) {
       const [path, size] = pending[index++];
       try {
-        // reload bypasses the HTTP cache so a precache always stores fresh bytes.
-        const response = await fetch(new Request(path, { cache: 'reload' }));
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        await cache.put(path, response);
+        await fetchAndCache(cache, path);
         bytes += size;
       } catch (err) {
         failed.push(path);
@@ -191,10 +212,11 @@ self.addEventListener('fetch', (event) => {
       const cache = await caches.open(CACHE);
       let cached = await cache.match(request, { ignoreSearch: true });
 
-      // Directory URLs like /phase-10/ are cached under their index.html.
+      // Pages are cached under their directory URL (/phase-10/), so map the
+      // other spellings of the same page onto it.
       if (!cached && request.mode === 'navigate') {
-        const base = url.pathname.endsWith('/') ? url.pathname : `${url.pathname}/`;
-        cached = await cache.match(`${base}index.html`);
+        const directory = url.pathname.replace(/index\.html$/, '');
+        cached = await cache.match(directory.endsWith('/') ? directory : `${directory}/`);
       }
 
       if (cached) {
@@ -206,7 +228,9 @@ self.addEventListener('fetch', (event) => {
         // Opportunistically keep anything the precache list missed. Only whole
         // responses: the Cache API rejects the 206 that a range request gets.
         if (response.status === 200 && response.type === 'basic') {
-          cache.put(request, response.clone());
+          const storable = await withoutRedirectFlag(response);
+          cache.put(request, storable.clone());
+          return storable;
         }
         return response;
       } catch (err) {
@@ -216,10 +240,10 @@ self.addEventListener('fetch', (event) => {
         if (request.mode === 'navigate') {
           const segments = url.pathname.split('/').filter(Boolean);
           if (segments.length) {
-            const gameIndex = await cache.match(`${self.registration.scope}${segments[0]}/index.html`);
-            if (gameIndex) return gameIndex;
+            const gameHome = await cache.match(`${self.registration.scope}${segments[0]}/`);
+            if (gameHome) return gameHome;
           }
-          const home = await cache.match(`${self.registration.scope}index.html`);
+          const home = await cache.match(self.registration.scope);
           if (home) return home;
         }
         throw err;

--- a/scripts/verify-offline.js
+++ b/scripts/verify-offline.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Checks that dist/ really plays offline.
+ *
+ *   node scripts/verify-offline.js
+ *
+ * Serves dist/ through a server that imitates Cloudflare Pages (including the
+ * 308 from /index.html to /), lets the service worker precache, then kills the
+ * server so nothing can possibly come from the network, and loads every game.
+ *
+ * The Pages-like redirects matter: a plain static server does not redirect
+ * /index.html, which hides the "Response served by service worker has
+ * redirections" failure that Safari — and only Safari — raises.
+ *
+ * Needs Playwright's Chromium (`npx playwright install chromium`).
+ */
+
+const { spawn } = require('child_process');
+const { execSync } = require('child_process');
+const path = require('path');
+
+function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch {}
+  try {
+    const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+    return require(path.join(globalRoot, 'playwright'));
+  } catch {}
+  console.error('❌ Playwright not found. Install it with:\n   npm i -g playwright && npx playwright install chromium');
+  process.exit(1);
+}
+
+const { chromium } = loadPlaywright();
+
+const PORT = Number(process.env.PORT || 8130);
+const BASE = `http://localhost:${PORT}`;
+const GAMES = require('./games-list.js');
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+(async () => {
+  const server = spawn(process.execPath, [path.join(__dirname, 'pages-server.js')], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: 'ignore',
+  });
+  await wait(1000);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const external = new Set();
+  context.on('request', (req) => {
+    const url = req.url();
+    if (!url.startsWith(BASE) && !url.startsWith('data:') && !url.startsWith('blob:')) external.add(url);
+  });
+
+  const failures = [];
+
+  console.log('→ precaching');
+  await page.goto(`${BASE}/`, { waitUntil: 'load' });
+  await page.waitForFunction(
+    () => document.querySelector('#offline-status')?.classList.contains('is-done'),
+    null,
+    { timeout: 300000 }
+  );
+
+  const { name, entries } = await page.evaluate(async () => {
+    const names = await caches.keys();
+    return { name: names[0], entries: (await (await caches.open(names[0])).keys()).length };
+  });
+  console.log(`   cache "${name}": ${entries} entries`);
+
+  // Safari refuses to serve a navigation response whose redirect flag is set.
+  // Chromium happily serves it, so assert the invariant rather than trusting
+  // that the page loaded here.
+  const redirected = await page.evaluate(async () => {
+    const cache = await caches.open((await caches.keys())[0]);
+    const bad = [];
+    for (const request of await cache.keys()) {
+      const res = await cache.match(request);
+      if (res && res.redirected) bad.push(new URL(request.url).pathname);
+    }
+    return bad;
+  });
+  if (redirected.length) {
+    failures.push('redirect flags');
+    console.log(`❌ ${redirected.length} cached response(s) carry a redirect flag — Safari will refuse these:`);
+    for (const p of redirected.slice(0, 6)) console.log(`     ${p}`);
+  } else {
+    console.log('✅ no cached response carries a redirect flag');
+  }
+
+  console.log('\n→ killing the server: only the cache can answer now');
+  server.kill('SIGKILL');
+  await wait(1000);
+
+  const reachable = await page.evaluate(async () => {
+    try {
+      await fetch(`/not-cached-${Date.now()}`, { cache: 'no-store' });
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (reachable) {
+    failures.push('server still up');
+    console.log('❌ the origin still answers — the rest of this run proves nothing');
+  } else {
+    console.log('   origin is down\n');
+  }
+
+  for (const label of ['', ...GAMES]) {
+    const url = `${BASE}/${label}${label ? '/' : ''}`;
+    const testPage = await context.newPage();
+    const problems = [];
+    testPage.on('requestfailed', (r) => problems.push(`${new URL(r.url()).pathname} ${r.failure()?.errorText}`));
+    testPage.on('pageerror', (e) => problems.push(String(e).split('\n')[0]));
+
+    let detail;
+    try {
+      const res = await testPage.goto(url, { waitUntil: 'load', timeout: 20000 });
+      await testPage.waitForTimeout(1500);
+      detail = `${res.status()} "${await testPage.title()}"`;
+    } catch (err) {
+      problems.push(String(err).split('\n')[0]);
+      detail = 'did not load';
+    }
+
+    const ok = problems.length === 0 && detail.startsWith('200');
+    if (!ok) failures.push(label || 'landing');
+    console.log(`${ok ? '✅' : '❌'} ${(label || 'landing').padEnd(22)} ${detail}${problems.length ? ` — ${problems[0]}` : ''}`);
+    await testPage.close();
+  }
+
+  // Safari asks for media with a Range header and rejects a plain 200.
+  const range = await page.evaluate(async () => {
+    const res = await fetch('/kpop-rythm-tap/songs/golden.mp3', { headers: { Range: 'bytes=0-99' } });
+    return { status: res.status, bytes: (await res.arrayBuffer()).byteLength };
+  });
+  const rangeOk = range.status === 206 && range.bytes === 100;
+  if (!rangeOk) failures.push('range request');
+  console.log(`${rangeOk ? '✅' : '❌'} range request on cached audio: ${JSON.stringify(range)}`);
+
+  if (external.size) {
+    failures.push('external requests');
+    console.log('❌ requests left the origin (these break offline):');
+    for (const url of external) console.log(`     ${url}`);
+  } else {
+    console.log('✅ nothing reaches off-origin');
+  }
+
+  await browser.close();
+
+  console.log(failures.length ? `\n💥 failed: ${failures.join(', ')}` : '\n🎉 offline verified');
+  process.exit(failures.length ? 1 : 0);
+})();


### PR DESCRIPTION
Fixes the offline support merged in #35, which broke normal page loads on production. **Merging this deploys the fix.**

## The bug

Cloudflare Pages 308-redirects `/index.html` → `/`. The worker precached pages by that name, so every one landed in the cache with its `redirected` flag set, and browsers refuse to serve such a response to a navigation. All 23 pages were affected — the landing page and every game.

Symptoms: on iOS, *"Response served by service worker has redirections"*. On desktop Chrome, a normal refresh fails while a force refresh works — a force refresh bypasses the service worker entirely, so it was the only thing still reaching the network.

This is live on `games.ross.dev` right now, and anyone who has visited since #35 merged has the broken worker installed.

## The fix

- **Precache pages under the URL the browser actually navigates to** (`/`, `/phase-10/`) instead of `/index.html`, so no redirect is followed on the way into the cache. Navigations to the other spellings map onto it.
- **Rebuild any response that still arrives redirected** before caching or serving it, which clears the flag. `Cache.addAll` offers no hook for this, so the shell precache is now written out by hand.
- **Include `sw-template.js` in the version hash.** It covered only `dist/` contents, so a worker-logic change kept the same cache name — devices with the broken worker would have installed the new one and kept their poisoned entries.
- **Don't let a single failed file abort install** (`Promise.allSettled`). A worker that can't finish installing can never replace a broken one already serving the site; the background precache refetches anything missed.

## Why this wasn't caught

Two things hid it. Chromium serves redirected responses without complaint in the normal case, and `npx serve dist` doesn't perform the `/index.html` redirect at all — so the failing condition never arose locally.

This PR adds `npm run verify:offline`, which closes both gaps. It serves through `scripts/pages-server.js` (imitates Pages, redirects included), asserts directly that no cached response carries a redirect flag rather than trusting a page load, then **kills the origin server** and loads every game from cache alone, so a pass can't be network-assisted.

## Verification

- The new check fails on the merged commit — 23 redirect-flagged entries, landing page dead offline — and passes here.
- 417 entries cached; landing page and all 22 games load with the origin process killed; cached audio still answers a range request with `206`; nothing reaches off-origin.
- **Recovery tested end to end**: built the worker exactly as merged to main, precached, confirmed a normal reload dies with `ERR_FAILED`, then deployed this build over it. The same browser healed itself — one transitional refresh, then the page loads and the old cache is replaced with all 417 entries.

Once this deploys, affected browsers recover on their own with a refresh or two. No cache clearing, unregistering, or re-adding the home screen icon.

Also moves the game list to `scripts/games-list.js` so the build and the offline check share one source of truth.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrvZioBpn1LBuUJPz9X5PQ)_