### PR TITLE
Neon Bricks: 50 levels and a level select

### DIFF
--- a/games/neon-bricks/src/game.ts
+++ b/games/neon-bricks/src/game.ts
@@ -11,7 +11,7 @@ import {
 import { AdvancedBloomFilter, GlowFilter, RGBSplitFilter, ShockwaveFilter } from 'pixi-filters';
 import { audio } from './audio';
 import { GameTextures, makeTextures, NeonBackground, ParticleSystem } from './fx';
-import { BrickSpec, getLevels, LevelDef, NEON } from './levels';
+import { BrickSpec, getLevels, LEVEL_COUNT, LevelDef, NEON } from './levels';
 import { Ease, killAllTweens, tween, tweenProps, updateTweens } from './tween';
 
 export const W = 900;
@@ -132,6 +132,8 @@ export class Game {
   private pausedFrom: GameState = 'playing';
   private levels: LevelDef[] = getLevels();
   private levelIndex = 0;
+  /** Highest level index the player has ever reached — the continue point. */
+  private unlocked = 0;
   private lives = 3;
   private score = 0;
   private displayScore = 0;
@@ -152,6 +154,7 @@ export class Game {
 
   // input buffering
   private pendingLaunch = false;
+  private buttons: { x: number; y: number; w: number; h: number; action: () => void }[] = [];
 
   // juice
   private shakeMag = 0;
@@ -172,6 +175,8 @@ export class Game {
     this.app = app;
     this.tex = makeTextures(app.renderer);
     this.best = Number(localStorage.getItem('neon-bricks-best') ?? 0) || 0;
+    const saved = Number(localStorage.getItem('neon-bricks-progress') ?? 0) || 0;
+    this.unlocked = Math.max(0, Math.min(this.levels.length - 1, Math.floor(saved)));
 
     this.bg = new NeonBackground(this.tex, W, H);
     this.fxUnder = new ParticleSystem(500);
@@ -309,7 +314,7 @@ export class Game {
     this.hud.addChild(this.comboBar);
 
     // level
-    this.levelText = new Text({ text: 'LV 1', style: chunkyStyle(22, 0xb537f2) });
+    this.levelText = new Text({ text: `LV 1/${LEVEL_COUNT}`, style: chunkyStyle(22, 0xb537f2) });
     this.levelText.anchor.set(0.5, 0);
     this.levelText.position.set(W / 2, 62);
     this.hud.addChild(this.levelText);
@@ -374,6 +379,33 @@ export class Game {
 
   private clearOverlay(): void {
     this.overlay.removeChildren().forEach((c) => c.destroy({ children: true }));
+    this.buttons = [];
+  }
+
+  /**
+   * Overlay button. Presses are hit-tested against these before the screen's
+   * default tap action, so "tap anywhere to play" still works around them.
+   */
+  private menuButton(label: string, y: number, color: number, size: number, action: () => void): void {
+    const t = new Text({
+      text: label,
+      style: { ...chunkyStyle(size, color, size >= 30 ? 5 : 4), letterSpacing: 2 },
+    });
+    t.anchor.set(0.5);
+    t.position.set(W / 2, y);
+
+    const padX = 34;
+    const padY = 14;
+    const w = t.width + padX * 2;
+    const h = t.height + padY * 2;
+    const frame = new Graphics()
+      .roundRect(W / 2 - w / 2, y - h / 2, w, h, 16)
+      .fill({ color: darken(color, 0.16), alpha: 0.5 })
+      .roundRect(W / 2 - w / 2, y - h / 2, w, h, 16)
+      .stroke({ width: 3, color });
+
+    this.overlay.addChild(frame, t);
+    this.buttons.push({ x: W / 2 - w / 2, y: y - h / 2, w, h, action });
   }
 
   private dimPanel(): Graphics {
@@ -424,21 +456,37 @@ export class Game {
       },
     );
 
-    const sub = new Text({
-      text: 'CLICK / TAP TO PLAY',
-      style: { ...chunkyStyle(34, 0xffee32, 6), letterSpacing: 3 },
+    const count = new Text({
+      text: `${LEVEL_COUNT} LEVELS`,
+      style: { ...chunkyStyle(30, 0x39ff14, 5), letterSpacing: 8 },
     });
-    sub.anchor.set(0.5);
-    sub.position.set(W / 2, 720);
-    this.overlay.addChild(sub);
-    this.blink(sub);
+    count.anchor.set(0.5);
+    count.position.set(W / 2, 640);
+    this.overlay.addChild(count);
+
+    if (this.unlocked > 0) {
+      // Returning player: default tap continues, with an explicit restart.
+      this.menuButton(`CONTINUE  •  LEVEL ${this.unlocked + 1}`, 730, 0xffee32, 34, () =>
+        this.startGame(this.unlocked),
+      );
+      this.menuButton('NEW GAME', 820, 0xff2d95, 26, () => this.startGame(0));
+    } else {
+      const sub = new Text({
+        text: 'CLICK / TAP TO PLAY',
+        style: { ...chunkyStyle(34, 0xffee32, 6), letterSpacing: 3 },
+      });
+      sub.anchor.set(0.5);
+      sub.position.set(W / 2, 740);
+      this.overlay.addChild(sub);
+      this.blink(sub);
+    }
 
     const hint = new Text({
       text: 'Move: mouse or drag  •  Launch: tap or SPACE',
       style: chunkyStyle(22, 0x8899dd),
     });
     hint.anchor.set(0.5);
-    hint.position.set(W / 2, 790);
+    hint.position.set(W / 2, this.unlocked > 0 ? 890 : 800);
     this.overlay.addChild(hint);
 
     if (this.best > 0) {
@@ -447,7 +495,7 @@ export class Game {
         style: chunkyStyle(26, 0xb537f2),
       });
       b.anchor.set(0.5);
-      b.position.set(W / 2, 860);
+      b.position.set(W / 2, this.unlocked > 0 ? 940 : 860);
       this.overlay.addChild(b);
     }
 
@@ -528,18 +576,35 @@ export class Game {
     mc.position.set(W / 2, 672);
     this.overlay.addChild(mc);
 
-    const again = new Text({
-      text: 'CLICK / TAP TO PLAY AGAIN',
-      style: { ...chunkyStyle(30, 0xffffff, 5), letterSpacing: 2 },
+    const reached = new Text({
+      text: win
+        ? `ALL ${LEVEL_COUNT} LEVELS CLEARED!`
+        : `REACHED LEVEL ${this.levelIndex + 1} OF ${LEVEL_COUNT}`,
+      style: chunkyStyle(24, 0x00f5ff),
     });
-    again.anchor.set(0.5);
-    again.position.set(W / 2, 790);
-    again.alpha = 0;
-    this.overlay.addChild(again);
-    tween(0.4, (t) => !again.destroyed && (again.alpha = t), {
-      delay: 0.9,
-      onComplete: () => !again.destroyed && this.blink(again),
-    });
+    reached.anchor.set(0.5);
+    reached.position.set(W / 2, 716);
+    this.overlay.addChild(reached);
+
+    if (win) {
+      const again = new Text({
+        text: 'CLICK / TAP TO PLAY AGAIN',
+        style: { ...chunkyStyle(30, 0xffffff, 5), letterSpacing: 2 },
+      });
+      again.anchor.set(0.5);
+      again.position.set(W / 2, 810);
+      again.alpha = 0;
+      this.overlay.addChild(again);
+      tween(0.4, (t) => !again.destroyed && (again.alpha = t), {
+        delay: 0.9,
+        onComplete: () => !again.destroyed && this.blink(again),
+      });
+    } else {
+      // Retrying the level you died on is the default — 50 levels is too far to redo.
+      const retryAt = this.levelIndex;
+      this.menuButton(`RETRY  •  LEVEL ${retryAt + 1}`, 810, 0xffee32, 32, () => this.startGame(retryAt));
+      if (retryAt > 0) this.menuButton('START OVER', 895, 0xff2d95, 24, () => this.startGame(0));
+    }
 
     if (win) {
       audio.winFanfare();
@@ -568,15 +633,16 @@ export class Game {
 
   // ------------------------------------------------------------ level flow
 
-  private startGame(): void {
+  private startGame(from = 0): void {
     this.score = 0;
     this.displayScore = 0;
     this.lives = 3;
     this.combo = 0;
     this.maxCombo = 0;
-    this.levelIndex = 0;
+    const start = Math.max(0, Math.min(this.levels.length - 1, from));
+    this.levelIndex = start;
     this.updateHearts();
-    this.loadLevel(0);
+    this.loadLevel(start);
   }
 
   private loadLevel(idx: number): void {
@@ -586,7 +652,8 @@ export class Game {
     this.state = 'transition';
     this.clearOverlay();
     this.clearEntities();
-    this.levelText.text = `LV ${idx + 1}`;
+    this.levelText.text = `LV ${idx + 1}/${this.levels.length}`;
+    this.saveProgress(idx);
 
     // Level banner
     const banner = this.bigTitle(`LEVEL ${idx + 1}`, NEON[idx % NEON.length], 480, 110);
@@ -745,11 +812,23 @@ export class Game {
     }
   }
 
-  onPress(): void {
+  onPress(x?: number, y?: number): void {
     audio.unlock();
+
+    // Overlay buttons win over the screen's default tap action.
+    if (x !== undefined && y !== undefined) {
+      const hit = this.buttons.find((btn) => x >= btn.x && x <= btn.x + btn.w && y >= btn.y && y <= btn.y + btn.h);
+      if (hit) {
+        this.clearOverlay();
+        hit.action();
+        return;
+      }
+    }
+
     switch (this.state) {
       case 'start':
-        this.startGame();
+        // Tapping anywhere else picks up where you left off.
+        this.startGame(this.unlocked);
         break;
       case 'playing':
         this.launchStuckBalls();
@@ -758,9 +837,12 @@ export class Game {
         this.resume();
         break;
       case 'gameover':
+        this.clearOverlay();
+        this.startGame(this.levelIndex);
+        break;
       case 'win':
         this.clearOverlay();
-        this.startGame();
+        this.startGame(0);
         break;
       case 'transition':
         // buffer the press — launch as soon as the level intro finishes
@@ -928,6 +1010,16 @@ export class Game {
         }
       },
     });
+  }
+
+  private saveProgress(idx: number): void {
+    if (idx <= this.unlocked) return;
+    this.unlocked = idx;
+    try {
+      localStorage.setItem('neon-bricks-progress', String(idx));
+    } catch {
+      // private browsing / storage full — progress just won't persist
+    }
   }
 
   private saveBest(): void {
@@ -1494,6 +1586,18 @@ export class Game {
 
   debugLoadLevel(n: number): void {
     if (n >= 0 && n < this.levels.length) this.loadLevel(n);
+  }
+
+  get debugLevelInfo(): { index: number; name: string; bricks: number; hits: number; top: number; bottom: number } {
+    const live = this.bricks.filter((b) => b.alive);
+    return {
+      index: this.levelIndex,
+      name: this.levels[this.levelIndex].name,
+      bricks: live.length,
+      hits: live.reduce((s, b) => s + b.hp, 0),
+      top: live.length ? Math.min(...live.map((b) => b.y - b.h / 2)) : 0,
+      bottom: live.length ? Math.max(...live.map((b) => b.y + b.h / 2)) : 0,
+    };
   }
 
   destroy(): void {

--- a/games/neon-bricks/src/levels.ts
+++ b/games/neon-bricks/src/levels.ts
@@ -23,103 +23,645 @@ export const NEON = [
   0xb537f2, // purple
 ];
 
+const WHITE = 0xffffff;
+
 function b(color: number, hp = 1): BrickSpec {
   return { color, hp };
 }
 
-/** Level 1 — Rainbow Cascade: classic rainbow rows, all 1-hit. */
-function rainbow(): LevelDef {
-  const cols = 10;
+/** Neon palette index (wraps) → brick. */
+function n(i: number, hp = 1): BrickSpec {
+  return { color: NEON[((i % NEON.length) + NEON.length) % NEON.length], hp };
+}
+
+/**
+ * A level before its ball speed is filled in. Speed ramps with level number
+ * unless a level opts out with an explicit value.
+ */
+interface LevelSeed {
+  name: string;
+  grid: (BrickSpec | null)[][];
+  cols: number;
+  ballSpeed?: number;
+}
+
+/**
+ * ASCII legend for `art()` levels.
+ *   lowercase letter = 1 hit, uppercase = 2 hits
+ *   p/o/y/g/c/b/u    = pink orange yellow green cyan blue pUrple
+ *   w/W              = white, X = white 3 hits, Z = white 4 hits
+ *   . or space       = empty
+ */
+const ART: Record<string, BrickSpec> = {
+  p: n(0), o: n(1), y: n(2), g: n(3), c: n(4), b: n(5), u: n(6), w: b(WHITE),
+  P: n(0, 2), O: n(1, 2), Y: n(2, 2), G: n(3, 2), C: n(4, 2), B: n(5, 2), U: n(6, 2), W: b(WHITE, 2),
+  X: b(WHITE, 3), Z: b(WHITE, 4),
+};
+
+/** Build a level from ASCII art. Short rows are padded with empty cells. */
+function art(name: string, rows: string[], ballSpeed?: number): LevelSeed {
+  const cols = Math.max(...rows.map((r) => r.length));
+  const grid = rows.map((line) => {
+    const cells: (BrickSpec | null)[] = [];
+    for (let c = 0; c < cols; c++) {
+      const spec = ART[line[c] ?? '.'];
+      cells.push(spec ? { ...spec } : null);
+    }
+    return cells;
+  });
+  return { name, grid, cols, ballSpeed };
+}
+
+/** Build a level from a per-cell function — for patterns math draws better than ASCII. */
+function shape(
+  name: string,
+  cols: number,
+  rows: number,
+  fn: (r: number, c: number) => BrickSpec | null,
+  ballSpeed?: number,
+): LevelSeed {
   const grid: (BrickSpec | null)[][] = [];
-  for (let r = 0; r < 7; r++) {
+  for (let r = 0; r < rows; r++) {
     const row: (BrickSpec | null)[] = [];
-    for (let c = 0; c < cols; c++) row.push(b(NEON[r % NEON.length]));
+    for (let c = 0; c < cols; c++) row.push(fn(r, c));
     grid.push(row);
   }
-  return { name: 'Rainbow Cascade', grid, cols, ballSpeed: 620 };
+  return { name, grid, cols, ballSpeed };
 }
+
+// ---------------------------------------------------------------- chapter 1
+
+/** Level 1 — Rainbow Cascade: classic rainbow rows, all 1-hit. */
+const rainbow = (): LevelSeed =>
+  shape('Rainbow Cascade', 10, 7, (r) => n(r));
 
 /** Level 2 — Neon Diamond: diamond shape, rings by color, tough core. */
-function diamond(): LevelDef {
-  const cols = 11;
-  const rows = 11;
-  const cx = (cols - 1) / 2;
-  const cy = (rows - 1) / 2;
-  const grid: (BrickSpec | null)[][] = [];
-  for (let r = 0; r < rows; r++) {
-    const row: (BrickSpec | null)[] = [];
-    for (let c = 0; c < cols; c++) {
-      const d = Math.abs(c - cx) + Math.abs(r - cy);
-      if (d > 5) {
-        row.push(null);
-      } else if (d <= 1) {
-        row.push(b(0xffffff, 3)); // blazing core
-      } else if (d <= 2) {
-        row.push(b(NEON[0], 2));
-      } else {
-        row.push(b(NEON[(d + 2) % NEON.length], 1));
-      }
-    }
-    grid.push(row);
-  }
-  return { name: 'Neon Diamond', grid, cols, ballSpeed: 680 };
-}
+const diamond = (): LevelSeed =>
+  shape('Neon Diamond', 11, 11, (r, c) => {
+    const d = Math.abs(c - 5) + Math.abs(r - 5);
+    if (d > 5) return null;
+    if (d <= 1) return b(WHITE, 3); // blazing core
+    if (d <= 2) return n(0, 2);
+    return n(d + 2);
+  });
 
 /** Level 3 — Big Smiley: yellow face, tough cyan eyes, pink smile. */
-function smiley(): LevelDef {
-  const cols = 12;
-  const art = [
-    '....####....',
-    '..########..',
-    '.##########.',
-    '.###EE##EE#.',
-    '####EE##EE##',
-    '############',
-    '####M####M##',
-    '.###MM##MM#.',
-    '.####MMMM##.',
-    '..########..',
-    '....####....',
-    '............',
-  ];
-  const grid: (BrickSpec | null)[][] = art.map((line) =>
-    line.split('').map((ch) => {
-      if (ch === '#') return b(NEON[2], 1); // yellow face
-      if (ch === 'E') return b(NEON[4], 2); // cyan eyes
-      if (ch === 'M') return b(NEON[0], 2); // pink mouth
-      return null;
-    }),
-  );
-  return { name: 'Big Smiley', grid, cols, ballSpeed: 720 };
-}
+const smiley = (): LevelSeed =>
+  art('Big Smiley', [
+    '....yyyy....',
+    '..yyyyyyyy..',
+    '.yyyyyyyyyy.',
+    '.yyyCCyyCCy.',
+    'yyyyCCyyCCyy',
+    'yyyyyyyyyyyy',
+    'yyyyPyyyyPyy',
+    '.yyyPPyyPPy.',
+    '.yyyyPPPPyy.',
+    '..yyyyyyyy..',
+    '....yyyy....',
+  ]);
 
 /** Level 4 — The Fortress: armored towers and a checkerboard heart. */
-function fortress(): LevelDef {
-  const cols = 11;
-  const rows = 10;
-  const grid: (BrickSpec | null)[][] = [];
-  for (let r = 0; r < rows; r++) {
-    const row: (BrickSpec | null)[] = [];
-    for (let c = 0; c < cols; c++) {
-      const isTower = c < 2 || c >= cols - 2;
-      if (isTower) {
-        row.push(r < 6 ? b(NEON[6], r < 2 ? 3 : 2) : null);
-      } else if (r >= 2 && r < 8) {
-        // checkerboard center
-        if ((r + c) % 2 === 0) row.push(b(NEON[(r + 3) % NEON.length], 1));
-        else if (r === 4 || r === 5) row.push(b(NEON[0], 2));
-        else row.push(null);
-      } else if (r < 2) {
-        row.push(b(NEON[4], 2));
-      } else {
-        row.push(null);
-      }
+const fortress = (): LevelSeed =>
+  shape('The Fortress', 11, 10, (r, c) => {
+    const isTower = c < 2 || c >= 9;
+    if (isTower) return r < 6 ? n(6, r < 2 ? 3 : 2) : null;
+    if (r < 2) return n(4, 2);
+    if (r >= 2 && r < 8) {
+      if ((r + c) % 2 === 0) return n(r + 3);
+      if (r === 4 || r === 5) return n(0, 2);
     }
-    grid.push(row);
-  }
-  return { name: 'The Fortress', grid, cols, ballSpeed: 760 };
+    return null;
+  });
+
+const waves = (): LevelSeed =>
+  shape('Neon Waves', 12, 9, (r, c) => {
+    const crest = 4 + Math.round(2.6 * Math.sin((c / 11) * Math.PI * 2));
+    const d = Math.abs(r - crest);
+    return d <= 2 ? n(c, d === 0 ? 2 : 1) : null;
+  });
+
+const invader = (): LevelSeed =>
+  art('Space Invader', [
+    '..g.....g..',
+    '...g...g...',
+    '..ggggggg..',
+    '.gg.ggg.gg.',
+    'ggggggggggg',
+    'g.gcgggcg.g',
+    'g.g.....g.g',
+    '...gg.gg...',
+  ]);
+
+const towers = (): LevelSeed =>
+  art('Twin Towers', [
+    '.uu......uu.',
+    '.uu......uu.',
+    '.UU......UU.',
+    '.UUccccccUU.',
+    '.UUccccccUU.',
+    '.UU......UU.',
+    '.UU......UU.',
+    '.WW......WW.',
+    'oooooooooooo',
+  ]);
+
+const checkers = (): LevelSeed =>
+  shape('Checkerboard', 12, 10, (r, c) => ((r + c) % 2 === 0 ? n(r, r >= 6 ? 2 : 1) : null));
+
+const arrow = (): LevelSeed =>
+  shape('Neon Arrow', 13, 11, (r, c) => {
+    const d = Math.abs(c - 6);
+    if (r < 6) return d <= r ? n(r + d, d === 0 ? 2 : 1) : null;
+    return d <= 1 ? n(4, 2) : null;
+  });
+
+const pyramid = (): LevelSeed =>
+  shape('Pyramid Power', 13, 8, (r, c) => {
+    const d = Math.abs(c - 6);
+    if (d > r) return null;
+    return n(6 - r, r === 7 ? 3 : r >= 5 ? 2 : 1);
+  });
+
+// ---------------------------------------------------------------- chapter 2
+
+const heart = (): LevelSeed =>
+  art('Heartbeat', [
+    '..ppp...ppp..',
+    '.ppppp.ppppp.',
+    'ppppppppppppp',
+    'pppppPPPppppp',
+    '.pppPPPPPppp.',
+    '..pppPPPppp..',
+    '...ppppppp...',
+    '....ppppp....',
+    '.....ppp.....',
+    '......p......',
+  ]);
+
+const starburst = (): LevelSeed =>
+  art('Starburst', [
+    '......y......',
+    '.....yyy.....',
+    '.....yyy.....',
+    'yyyyyyyyyyyyy',
+    '.yyyyOOOyyyy.',
+    '..yyyOOOyyy..',
+    '...yyyyyyy...',
+    '...yyy.yyy...',
+    '..yy.....yy..',
+    '.yy.......yy.',
+  ]);
+
+const ladder = (): LevelSeed =>
+  shape('Zigzag Ladder', 12, 11, (r, c) => {
+    if (c === 0 || c === 11) return n(6, 2); // rails
+    if (r % 2 === 1) return null;
+    const rung = r % 4 === 0 ? c < 7 : c > 4;
+    return rung ? n(r / 2) : null;
+  });
+
+const wall = (): LevelSeed =>
+  shape('Brick Wall', 14, 10, (r, c) => {
+    const mortar = (c + (r % 2)) % 4 === 3;
+    if (mortar) return null;
+    return n(r + Math.floor(c / 4), r >= 6 ? 2 : 1);
+  });
+
+const eye = (): LevelSeed =>
+  art('The Eye', [
+    '....ccccc....',
+    '..ccccccccc..',
+    '.ccccUUUcccc.',
+    'cccccUXUccccc',
+    'cccccUUUccccc',
+    '.ccccUUUcccc.',
+    '..ccccccccc..',
+    '....ccccc....',
+  ]);
+
+const rocket = (): LevelSeed =>
+  art('Rocket Launch', [
+    '.....p.....',
+    '....ppp....',
+    '...ppppp...',
+    '...pPCPp...',
+    '...pPCPp...',
+    '...ppppp...',
+    '..ppppppp..',
+    '.pp.ppp.pp.',
+    '.p...o...p.',
+    '....ooo....',
+    '...ooooo...',
+    '....ooo....',
+  ]);
+
+const honeycomb = (): LevelSeed =>
+  shape('Honeycomb', 13, 11, (r, c) => {
+    const cell = (c + (r % 2)) % 3;
+    if (cell === 0) return null;
+    return n(cell === 1 ? 2 : 1, r % 3 === 0 ? 2 : 1);
+  });
+
+const skull = (): LevelSeed =>
+  art('Neon Skull', [
+    '..wwwwwwww..',
+    '.wwwwwwwwww.',
+    'wwwwwwwwwwww',
+    'ww.PP..PP.ww',
+    'ww.PP..PP.ww',
+    'wwwwwwwwwwww',
+    'wwww.OO.wwww',
+    '.wwwwwwwwww.',
+    '...w.w.w.w..',
+  ]);
+
+const snake = (): LevelSeed =>
+  shape('Neon Snake', 13, 11, (r, c) => {
+    if (r % 2 === 1) {
+      const side = ((r - 1) / 2) % 2 === 0 ? 12 : 0;
+      return c === side ? n(3, 2) : null;
+    }
+    return n(3 + ((r / 2) % 3), r === 0 ? 2 : 1);
+  });
+
+const gauntlet = (): LevelSeed =>
+  shape('The Gauntlet', 12, 12, (r, c) => {
+    if (c % 3 === 1) return null; // corridors
+    if (r < 3) return b(WHITE, 2);
+    return n(c, r >= 9 ? 2 : 1);
+  });
+
+// ---------------------------------------------------------------- chapter 3
+
+const ghost = (): LevelSeed =>
+  art('Ghost Chase', [
+    'y.y.y.y.y.y.y',
+    '...uuuuuuu...',
+    '..uuuuuuuuu..',
+    '.uuwwuuuwwuu.',
+    '.uuCwuuuCwuu.',
+    'uuuuuuuuuuuuu',
+    'uuuuuuuuuuuuu',
+    'uuuuuuuuuuuuu',
+    'uu.uu.u.uu.uu',
+  ]);
+
+const mushroom = (): LevelSeed =>
+  art('Mushroom', [
+    '...pppppp...',
+    '.pppppppppp.',
+    'pppwwppwwppp',
+    'pppwwppwwppp',
+    'pppppppppppp',
+    '.wwwwwwwwww.',
+    '...wwwwww...',
+    '...wwwwww...',
+    '...wwwwww...',
+  ]);
+
+const soundwave = (): LevelSeed =>
+  shape('Sound Wave', 14, 12, (r, c) => {
+    const heights = [3, 6, 9, 5, 11, 7, 12, 12, 7, 11, 5, 9, 6, 3];
+    return r >= 12 - heights[c] ? n(c, r >= 10 ? 2 : 1) : null;
+  });
+
+const crossfire = (): LevelSeed =>
+  shape('Crossfire', 13, 13, (r, c) => {
+    const onX = Math.abs(r - c) <= 1 || Math.abs(r - (12 - c)) <= 1;
+    return onX ? n(Math.abs(r - 6), r === 6 ? 3 : 2) : null;
+  });
+
+const cathedral = (): LevelSeed =>
+  shape('Cathedral', 13, 11, (r, c) => {
+    const bay = c % 4;
+    if (bay === 0) return n(6, 2); // pillars
+    if (r < 3 && bay !== 2) return null; // arch openings
+    return n(r + c);
+  });
+
+const fleet = (): LevelSeed =>
+  art('Alien Fleet', [
+    '.cc...cc...cc.',
+    'cccc.cccc.cccc',
+    'c..c.c..c.c..c',
+    '..............',
+    '.gg...gg...gg.',
+    'gggg.gggg.gggg',
+    'g..g.g..g.g..g',
+    '..............',
+    '.pp...pp...pp.',
+    'pppp.pppp.pppp',
+    'p..p.p..p.p..p',
+  ]);
+
+const vortex = (): LevelSeed =>
+  shape('Vortex', 13, 13, (r, c) => {
+    const dx = c - 6;
+    const dy = r - 6;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist > 6.5) return null;
+    const swirl = (Math.atan2(dy, dx) / Math.PI + dist / 2.2 + 4) % 2;
+    return swirl < 1 ? n(Math.round(dist), dist < 2 ? 3 : 1) : null;
+  });
+
+const blocks = (): LevelSeed =>
+  shape('Block Party', 12, 12, (r, c) => {
+    const br = Math.floor(r / 2);
+    const bc = Math.floor(c / 2);
+    const on = (br * 7 + bc * 5 + br * bc) % 3 !== 0;
+    return on ? n(br + bc, br >= 4 ? 2 : 1) : null;
+  });
+
+const butterfly = (): LevelSeed =>
+  art('Butterfly', [
+    '.uuu..u..uuu.',
+    'uuuuu.u.uuuuu',
+    'uuuuu.u.uuuuu',
+    '.uuu..u..uuu.',
+    '..u...W...u..',
+    '.ppp..W..ppp.',
+    'ppppp.W.ppppp',
+    '.ppp..W..ppp.',
+    '..p...W...p..',
+  ]);
+
+const vault = (): LevelSeed =>
+  shape('The Vault', 12, 11, (r, c) => {
+    if (r === 0 || r === 10 || c === 0 || c === 11) return b(WHITE, 2);
+    const dx = Math.abs(c - 5.5);
+    const dy = Math.abs(r - 5);
+    if (dx <= 2 && dy <= 2) return n(0, 2);
+    return (r + c) % 2 === 0 ? n(r + c) : null;
+  });
+
+// ---------------------------------------------------------------- chapter 4
+
+const circuit = (): LevelSeed =>
+  shape('Circuit Board', 14, 11, (r, c) => {
+    if (r % 2 === 0) return n(3, r === 0 || r === 10 ? 2 : 1); // traces
+    return c % 3 === 1 ? n(4, 2) : null; // vias
+  });
+
+const egg = (): LevelSeed =>
+  art('Dragon Egg', [
+    '...ggggg...',
+    '..ggggggg..',
+    '.ggggggggg.',
+    '.gggGGGggg.',
+    'ggggGGGgggg',
+    'gggGGXGGggg',
+    'ggggGGGgggg',
+    '.gggGGGggg.',
+    '.ggggggggg.',
+    '..ggggggg..',
+    '...ggggg...',
+  ]);
+
+const crystal = (): LevelSeed =>
+  art('Ice Crystal', [
+    '......c......',
+    '.c....c....c.',
+    '..c...c...c..',
+    '...ccccccc...',
+    '..cccCCCccc..',
+    'CCcccCWCcccCC',
+    '..cccCCCccc..',
+    '...ccccccc...',
+    '..c...c...c..',
+    '.c....c....c.',
+    '......c......',
+  ]);
+
+const robot = (): LevelSeed =>
+  art('Robot Face', [
+    '..b......b..',
+    '..b......b..',
+    '.wwwwwwwwww.',
+    'wwCCwwwwCCww',
+    'wwCCwwwwCCww',
+    'wwwwwwwwwwww',
+    'ww.OOOOOO.ww',
+    'ww.O.OO.O.ww',
+    'wwwwwwwwwwww',
+    '.wwwwwwwwww.',
+  ]);
+
+const helix = (): LevelSeed =>
+  shape('Double Helix', 12, 13, (r, c) => {
+    const a = (r / 12) * Math.PI * 2.5;
+    const s1 = 5.5 + 5 * Math.sin(a);
+    const s2 = 5.5 - 5 * Math.sin(a);
+    if (Math.abs(c - s1) < 0.75) return n(4, 2);
+    if (Math.abs(c - s2) < 0.75) return n(0, 2);
+    const inner = c > Math.min(s1, s2) && c < Math.max(s1, s2);
+    return r % 3 === 0 && inner ? n(2) : null;
+  });
+
+const rain = (): LevelSeed =>
+  shape('Rain Curtain', 14, 12, (r, c) => {
+    const len = 4 + ((c * 5) % 8);
+    const start = (c * 3) % 4;
+    if (r < start || r >= start + len) return null;
+    return n(5 + (c % 2), r === start ? 2 : 1);
+  });
+
+const castle = (): LevelSeed =>
+  shape('Castle Siege', 13, 12, (r, c) => {
+    if (r === 0) return c % 2 === 0 ? b(WHITE, 2) : null; // crenellations
+    if (r <= 2) return b(WHITE, 2);
+    if (c === 0 || c === 12 || c === 6) return n(6, 2); // towers
+    if (r >= 10) return n(r + c, 2);
+    return (r + c) % 3 !== 0 ? n(c) : null;
+  });
+
+const cat = (): LevelSeed =>
+  art('Neon Cat', [
+    '.o........o.',
+    '.oo......oo.',
+    '.oooooooooo.',
+    'oooooooooooo',
+    'ooGGooooGGoo',
+    'ooGGooooGGoo',
+    'oooooPPooooo',
+    'oo.oooooo.oo',
+    '.oooooooooo.',
+    '..oooooooo..',
+  ]);
+
+const meteors = (): LevelSeed =>
+  shape('Meteor Shower', 14, 12, (r, c) => {
+    const streak = (r + c) % 4;
+    return streak <= 1 ? n(r + c, r >= 8 ? 2 : 1) : null;
+  });
+
+const labyrinth = (): LevelSeed =>
+  shape('The Labyrinth', 13, 12, (r, c) => {
+    if (r % 2 === 0) {
+      const gap = (r * 5 + 3) % 13;
+      return c === gap ? null : n(6, r % 4 === 0 ? 2 : 1);
+    }
+    return (c + r) % 4 === 0 ? n(4) : null;
+  });
+
+// ---------------------------------------------------------------- chapter 5
+
+const jellyfish = (): LevelSeed =>
+  art('Cosmic Jellyfish', [
+    '...uuuuuuu...',
+    '.uuuuuuuuuuu.',
+    'uuuuuuuuuuuuu',
+    'uuuCCuuuCCuuu',
+    'uuuuuuuuuuuuu',
+    '.uuuuuuuuuuu.',
+    'p.p.p.p.p.p.p',
+    '.p.p.p.p.p.p.',
+    'p.p.p.p.p.p.p',
+    '.p.p.p.p.p.p.',
+  ]);
+
+const bolt = (): LevelSeed =>
+  art('Power Chord', [
+    '......YYYY..',
+    '.....YYYY...',
+    '....YYYY....',
+    '...YYYY.....',
+    '..YYYYYYY...',
+    '.....YYYY...',
+    '....YYYY....',
+    '...YYYY.....',
+    '..YYYY......',
+    '.YYY........',
+    'oooooooooooo',
+    '.oooooooooo.',
+  ]);
+
+const bomb = (): LevelSeed =>
+  art('Time Bomb', [
+    '.......oo..',
+    '......oo...',
+    '.....oo....',
+    '...wwwww...',
+    '..wwwwwww..',
+    '.wwwwwwwww.',
+    'wwwwXXXwwww',
+    'wwwwXXXwwww',
+    '.wwwwwwwww.',
+    '..wwwwwww..',
+    '...wwwww...',
+  ]);
+
+const web = (): LevelSeed =>
+  shape('Spider Web', 13, 12, (r, c) => {
+    const dx = c - 6;
+    const dist = Math.sqrt(dx * dx + r * r);
+    if (dist > 12) return null;
+    const ring = Math.abs(dist - Math.round(dist / 2.5) * 2.5) < 0.6;
+    const spoke = Math.abs(dx) < 0.6 || Math.abs(Math.abs(dx) - r) < 0.6;
+    return ring || spoke ? n(4, dist < 4 ? 2 : 1) : null;
+  });
+
+const phoenix = (): LevelSeed =>
+  art('Phoenix Rising', [
+    '..O.......O..',
+    '.OO.......OO.',
+    '.ooo.....ooo.',
+    '.oooo...oooo.',
+    '.ooooo.ooooo.',
+    '..ooo.O.ooo..',
+    '...oo.O.oo...',
+    '....YYOYY....',
+    '...YYYOYYY...',
+    '..yyy.O.yyy..',
+    '.yy.......yy.',
+  ]);
+
+const fractal = (): LevelSeed =>
+  shape('Fractal Bloom', 13, 13, (r, c) => {
+    const on = (r & c) === 0 || ((12 - r) & c) === 0;
+    return on ? n(r + c, r >= 8 ? 2 : 1) : null;
+  });
+
+const colosseum = (): LevelSeed =>
+  shape('The Colosseum', 13, 11, (r, c) => {
+    const dx = c - 6;
+    const dy = (r - 5) * 1.15;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d > 6.6) return null;
+    const ring = Math.floor(d);
+    if (ring % 2 === 0) return n(ring, ring <= 1 ? 3 : 2); // tiers
+    // radial spokes spanning the gaps between tiers
+    return Math.abs(Math.cos(Math.atan2(dy, dx) * 6)) > 0.8 ? n(1) : null;
+  });
+
+const galaxy = (): LevelSeed =>
+  shape('Galaxy Spiral', 14, 13, (r, c) => {
+    const dx = c - 6.5;
+    const dy = (r - 6) * 1.3;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d > 7.5) return null;
+    if (d < 1.6) return b(WHITE, 3);
+    const arm = Math.abs(Math.sin(Math.atan2(dy, dx) + d * 0.55));
+    return arm > 0.72 ? n(Math.round(d), d < 4 ? 2 : 1) : null;
+  });
+
+const finalFortress = (): LevelSeed =>
+  shape('Final Fortress', 13, 12, (r, c) => {
+    if (r === 0 || r === 11 || c === 0 || c === 12) return b(WHITE, 2);
+    if (r === 1 || r === 10 || c === 1 || c === 11) return n(6);
+    const dx = Math.abs(c - 6);
+    const dy = Math.abs(r - 5.5);
+    if (dx + dy * 1.2 <= 3) return n(0, 3);
+    return (r + c) % 2 === 0 ? n(r + c) : null;
+  });
+
+const supernova = (): LevelSeed =>
+  shape('Supernova', 13, 13, (r, c) => {
+    const dx = c - 6;
+    const dy = r - 6;
+    const d = Math.sqrt(dx * dx + dy * dy);
+    if (d > 6.6) return null;
+    if (d < 1.2) return b(WHITE, 4);
+    const spike = Math.abs(Math.cos(Math.atan2(dy, dx) * 4));
+    if (d >= 2.6 && spike <= 0.55) return null;
+    return n(6 - Math.round(d), d < 3 ? 3 : d < 5 ? 2 : 1);
+  });
+
+// ----------------------------------------------------------------- assembly
+
+const BUILDERS: (() => LevelSeed)[] = [
+  // chapter 1 — warm-up
+  rainbow, diamond, smiley, fortress, waves,
+  invader, towers, checkers, arrow, pyramid,
+  // chapter 2 — shapes with teeth
+  heart, starburst, ladder, wall, eye,
+  rocket, honeycomb, skull, snake, gauntlet,
+  // chapter 3 — arcade icons
+  ghost, mushroom, soundwave, crossfire, cathedral,
+  fleet, vortex, blocks, butterfly, vault,
+  // chapter 4 — machinery
+  circuit, egg, crystal, robot, helix,
+  rain, castle, cat, meteors, labyrinth,
+  // chapter 5 — the long haul
+  jellyfish, bolt, bomb, web, phoenix,
+  fractal, colosseum, galaxy, finalFortress, supernova,
+];
+
+export const LEVEL_COUNT = BUILDERS.length;
+
+/** Ball speed ramps steadily from level 1 to the last, staying under the 980 cap. */
+function speedFor(idx: number): number {
+  return Math.round(620 + (idx / (BUILDERS.length - 1)) * 310);
 }
 
 export function getLevels(): LevelDef[] {
-  return [rainbow(), diamond(), smiley(), fortress()];
+  return BUILDERS.map((build, i) => {
+    const seed = build();
+    return {
+      name: seed.name,
+      grid: seed.grid,
+      cols: seed.cols,
+      ballSpeed: seed.ballSpeed ?? speedFor(i),
+    };
+  });
 }

--- a/games/neon-bricks/src/main.ts
+++ b/games/neon-bricks/src/main.ts
@@ -33,6 +33,10 @@ async function boot(): Promise<void> {
     const rect = app.canvas.getBoundingClientRect();
     return ((clientX - rect.left) / rect.width) * W;
   }
+  function toGameY(clientY: number): number {
+    const rect = app.canvas.getBoundingClientRect();
+    return ((clientY - rect.top) / rect.height) * H;
+  }
 
   let pointerDown = false;
   let downX = 0;
@@ -55,7 +59,7 @@ async function boot(): Promise<void> {
     pointerDown = false;
     // treat as a tap when it wasn't a long drag
     const wasDrag = moved && Math.abs(e.clientX - downX) > 24 && performance.now() - downTime > 250;
-    if (!wasDrag) game.onPress();
+    if (!wasDrag) game.onPress(toGameX(e.clientX), toGameY(e.clientY));
   });
   window.addEventListener('pointercancel', () => {
     pointerDown = false;


### PR DESCRIPTION
The game shipped with a handful of hand-written brick grids. Building levels that way does not scale, and there was no way back to one you had already cleared.

Levels are now declared two ways, whichever suits the pattern:

- `art()` takes rows of ASCII and a legend, for anything with a recognisable silhouette — the invader, the skull, the cat.
- `shape()` takes a per-cell function, for patterns maths draws better than a picture does: the waves are a sine crest, the diamond and pyramid are distance fields.

That gives 50 levels across five chapters, from the opening rainbow to supernova. Ball speed ramps with level index rather than being set per level, staying under the existing 980 cap, so inserting or reordering a level cannot accidentally spike the difficulty.

Clearing a level unlocks the next; the highest reached is kept in localStorage and the title screen offers a level select, so nobody has to replay thirty levels to get back to where they were. Pointer presses now carry their coordinates so the menu can hit-test buttons — `onPress()` previously took no arguments because the only thing it ever did was launch the ball.