### PR TITLE
Let the ball actually reach the flippers

### DIFF
--- a/games/pinball/CLAUDE.md
+++ b/games/pinball/CLAUDE.md
@@ -59,6 +59,47 @@ These were all real bugs; the numbers matter.
   table, and the orbit returns the ball down the left every launch. Fixed by
   pulling the outer walls in and adding kickbacks. Flipper contacts went from
   near zero to ~40 per ball.
+- **That fix did not hold, and `flipHits / serves` did not catch it.** Contacts
+  per ball stayed in the tens while 76% of balls still died in the outlanes —
+  the autoplay bot flips ~5x/second, so it racks up contacts on the few balls
+  that do come down and tells you nothing about the ones that never arrive.
+  What exposes it is dropping balls with **no flipping at all** and asking how
+  many reach the bats. Only 24% did.
+- **The lane commit is binary, and it happens at y≈1000.** Bucketing passive
+  drops by the x they cross y=1000 gives ~100% reaching the bats inside a
+  corridor and ~0% outside it — there is no gradient. So the number to move is
+  the *width of that corridor*, not anything about the outlane itself. It was
+  x∈[200,600]; it is now x∈[160,680], which took reach from 24% to 73%.
+- **Guide height matters far more than mouth width.** A 37 px aperture at
+  y=968 let 13% of balls into the outlane; a 36 px aperture at y=1000 let in
+  45%. Near-identical gaps, wildly different outcomes — what counts is how
+  early the guide's inward-leaning face starts shedding balls, not how tight
+  the gap is. Tune `GUIDE_LEFT[0]` (currently `[133, 980]`); lower/inboard is
+  harder, higher/outboard is more forgiving.
+- **Do not extend the guides much above y≈980.** At `[128, 968]` reach hits
+  88% and the outlanes effectively close, but the guide then walls off the
+  channels the ball uses to get *back up* to the targets and orbit, and games
+  stop ending. Closing an outlane and blocking a shot lane are the same edit
+  at different heights.
+- **An aperture narrower than 28 px seals rather than narrows.** `[128, 1000]`
+  computes to 22.6 px of clear width, so no ball ever enters the outlane —
+  it wedges in the mouth instead. Always check the arithmetic against the ball
+  diameter before trusting a probe result that looks too good.
+- **`POSTS` is empty and should stay that way unless a post earns its place.**
+  All five sat where they deflected balls outward into an outlane, and they
+  cost ~14 points of reach between them. The pair at y=924 is the subtle one:
+  it sits just above the outer star rollovers, close enough that players blame
+  the stars — which are triggers with no collider and cannot trap anything.
+  Before moving a rollover, check whether a post is the real culprit.
+- **The slingshots were 22% too big.** At their original size the bodies
+  crowded the space directly in front of the bats and left only a 56px channel
+  between their inner tips. Scaling them down about their centroids opened
+  that to 84px and lifted the bottom corner clear of the flipper, worth ~5
+  points of reach on its own.
+- `WALL_RIGHT` now mirrors `WALL_LEFT` instead of repeating the literals.
+  While they were independent, a change to the left wall left the right
+  aperture 8 px narrower — under a ball width — and balls wedged there. If you
+  edit one outer wall, the other must follow, so let the code do it.
 - A kickback must fire the ball **from where it stands**. Teleporting it onto
   the kicker's own coordinates put it inside the outer wall, so it was shoved
   back out and drained anyway — 97 kicks produced 97 outlane drains.
@@ -109,9 +150,15 @@ pacing must be measured in game time, not wall time. Watch for `longest stall`
 above ~0.5 s (a ball trapped somewhere) and check every feature in the
 `features:` line still fires.
 
-**The metric that matters is `flipHits / serves` — flipper contacts per ball.**
-Time-in-zone percentages look reasonable even when the table is quietly killing
-every ball somewhere the player can't reach; contacts per ball does not. It
-should sit in the tens. `stats.drainX` records where each ball actually died:
-bucket it and check the deaths are near the flipper gap (x ~384-420) rather
-than out at the edges.
+**The metric that matters is `stats.drainX` — where balls actually die.** Bucket
+it and check the deaths are near the flipper gap (x ~384-420) rather than out at
+the edges (x ~235-260 and ~540-570, the outlanes). `flipHits / serves` is *not*
+sufficient on its own: it sat in the tens through a period when three quarters of
+balls were dying unreachably, because the bot flails at whatever does come down.
+
+Neither harness answers "can the ball reach the flippers at all", because both
+flip constantly. For that, drop balls with no flipping and count how many reach
+the bats — see the passive-drop findings above. Note also that the bot defends
+the centre drain near-perfectly, so once the outlanes are fair it stops losing
+and games run past the 600 s cap; that is an artefact of the bot, not
+necessarily of the table. Judge difficulty from `drainX` and from playing it.

--- a/games/pinball/playtest.mjs
+++ b/games/pinball/playtest.mjs
@@ -21,7 +21,7 @@ const server = http.createServer((req, res) => {
 await new Promise((r) => server.listen(PORT, r));
 
 const browser = await chromium.launch({
-  executablePath: '/opt/pw-browsers/chromium',
+  executablePath: process.env.PW_CHROMIUM ?? '/opt/pw-browsers/chromium',
   args: ['--use-gl=swiftshader', '--enable-unsafe-swiftshader'],
 });
 const page = await browser.newPage({ viewport: { width: 500, height: 620 } });

--- a/games/pinball/smoke.mjs
+++ b/games/pinball/smoke.mjs
@@ -37,7 +37,7 @@ await new Promise((r) => server.listen(PORT, r));
 const errors = [];
 const failed = [];
 const browser = await chromium.launch({
-  executablePath: '/opt/pw-browsers/chromium',
+  executablePath: process.env.PW_CHROMIUM ?? '/opt/pw-browsers/chromium',
   args: ['--use-gl=swiftshader', '--enable-unsafe-swiftshader'],
 });
 const page = await browser.newPage({ viewport: { width: 900, height: 1100 }, deviceScaleFactor: 1 });

--- a/games/pinball/src/table.ts
+++ b/games/pinball/src/table.ts
@@ -76,8 +76,20 @@ export interface SlingDef {
   x2: number; y2: number;
   x3: number; y3: number;
 }
-export const SLING_L: SlingDef = { x1: 278, y1: 1072, x2: 274, y2: 1176, x3: 374, y3: 1144 };
-export const SLING_R: SlingDef = { x1: 526, y1: 1072, x2: 530, y2: 1176, x3: 430, y3: 1144 };
+/**
+ * Scaled ~22% down about the centroid from the original
+ * (278,1072)/(274,1176)/(374,1144): the bodies crowded the space directly in
+ * front of the bats. Shrinking lifts the bottom corner 10px clear of the
+ * flipper and opens the centre channel between the two inner tips from 56px
+ * to 84px, so a ball coming down the middle has somewhere to go.
+ */
+export const SLING_L: SlingDef = { x1: 285, y1: 1085, x2: 282, y2: 1166, x3: 360, y3: 1141 };
+/** Mirrored, so the pair can't drift apart the way the outer walls once did. */
+export const SLING_R: SlingDef = {
+  x1: 2 * PF_CX - SLING_L.x1, y1: SLING_L.y1,
+  x2: 2 * PF_CX - SLING_L.x2, y2: SLING_L.y2,
+  x3: 2 * PF_CX - SLING_L.x3, y3: SLING_L.y3,
+};
 
 // --- drop targets -----------------------------------------------------------
 export interface TargetDef { x: number; y: number; angle: number }
@@ -95,14 +107,15 @@ export const TARGETS_R: TargetDef[] = TARGETS_L.map((t) => ({
 }));
 
 // --- posts, rollovers, saucer ----------------------------------------------
-export const POSTS: { x: number; y: number; r: number }[] = [
-  { x: 402, y: 1086, r: 14 },
-  { x: 226, y: 924, r: 13 },
-  { x: 578, y: 924, r: 13 },
-  // rubber at the mouth of each outlane, so cheap side drains are rarer
-  { x: 196, y: 1032, r: 13 },
-  { x: 608, y: 1032, r: 13 },
-];
+/**
+ * Empty on purpose. Every post that used to live here sat where it deflected
+ * balls outward into an outlane: a pair at y=924 just above the outer star
+ * rollovers (players read them as part of that cluster and reported balls
+ * being trapped to the gutters there), a pair at the outlane mouths, and one
+ * dead centre at y=1086 directly above the flipper gap. Removing all five is
+ * worth ~14 points of "balls that reach a bat" between them.
+ */
+export const POSTS: { x: number; y: number; r: number }[] = [];
 
 /** Big painted planet that anchors the middle of the table. */
 export const PLANET_X = 402;
@@ -155,17 +168,20 @@ type Poly = [number, number][];
 export const WALL_LEFT: Poly = [
   [LEFT_X, ARCH_CY],
   [LEFT_X, 894],
-  [126, 1044],
-  [150, 1160],
-  [174, 1292],
+  [108, 1040],
+  [132, 1160],
+  [168, 1292],
   [192, APRON_Y + 20],
 ];
+/**
+ * Mirrors the left wall's lower run rather than repeating the numbers. When
+ * these were two independent lists the right outlane aperture silently drifted
+ * 8px narrower than the left, which is under a ball width once you add the
+ * wall radii — balls wedged in the mouth and never came down.
+ */
 export const WALL_RIGHT: Poly = [
   [DIV_X, 894],
-  [2 * PF_CX - 126, 1044],
-  [2 * PF_CX - 150, 1160],
-  [2 * PF_CX - 174, 1292],
-  [2 * PF_CX - 192, APRON_Y + 20],
+  ...WALL_LEFT.slice(2).map(([x, y]) => [2 * PF_CX - x, y] as [number, number]),
 ];
 export const WALL_DIVIDER: Poly = [
   [DIV_X, DIV_TOP_Y],
@@ -184,10 +200,20 @@ export const WALL_LANE_FLOOR: Poly = [
  * clears the flipper bat: it catches the ball out of the inlane and rolls it
  * onto the middle of the bat. Earlier revisions funnelled the inlane shut and
  * the ball wedged permanently beside the flipper's pivot.
+ *
+ * The top point is the table's difficulty knob. It decides how early the
+ * inward-leaning face starts shedding balls away from the outlane, which is
+ * what actually sets the share of balls that reach the bats — the width of the
+ * outlane mouth barely matters next to it. At [196, 1046] only 24% of balls
+ * arrived at a flipper; at [133, 980] it is 73%. Lower and inboard is harder.
+ * Two limits: above y≈980 the guide starts blocking the channels the ball uses
+ * to get back up the table, and any aperture under 28px seals the outlane and
+ * wedges the ball instead of narrowing it.
  */
 export const GUIDE_LEFT: Poly = [
-  [196, 1046],
-  [206, 1152],
+  [133, 980],
+  [176, 1052],
+  [200, 1152],
   [234, 1216],
   [282, 1240],
 ];


### PR DESCRIPTION
Three quarters of balls were dying in the outlanes without ever passing a bat, and the metric in use — flipper contacts per ball — stayed healthy throughout, because the autoplay bot flips ~5x/second and racks up contacts on the few balls that do come down.

Dropping balls with no flipping at all is what exposes it: only 24% reached a flipper. The commit to a lane turns out to be binary and to happen at y≈1000, so the number worth moving is the width of that corridor, not anything about the outlane. It was x∈[200,600]; it is now x∈[160,680], and reach is 73%.

- GUIDE_LEFT is the difficulty knob: how early its inward-leaning face starts shedding balls matters far more than the mouth width. A 37px aperture at y=968 leaked 13%; a 36px one at y=1000 leaked 45%.
- POSTS is now empty. All five sat where they deflected balls outward into an outlane, ~14 points of reach between them. The pair at y=924 is the subtle one — it sits just above the outer star rollovers, so players blame the stars, which are triggers with no collider.
- The slingshots were 22% too big, crowding the space in front of the bats; scaling them about their centroids opens the centre channel from 56px to 84px.
- WALL_RIGHT and SLING_R now mirror their left counterparts instead of repeating literals. While independent, the right aperture had drifted 8px narrower than the left — under a ball width — and balls wedged.

The bounds are in CLAUDE.md: above y≈980 the guide walls off the channels the ball needs to get back up the table, and any aperture under 28px seals the outlane rather than narrowing it.

Both harnesses take PW_CHROMIUM for the browser path, so they run outside the container that has /opt/pw-browsers.