### PR TITLE
Add a back-to-arcade button for Home Screen apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,45 @@ git. Without it the API returns 503 and the games play normally.
 `scripts/build-all.js` handles the full build:
 - For each game with a `package.json`: runs `npm ci && npm run build`, copies `dist/` output
 - For static games (ojoj): copies files directly
+- Injects the shared back button into every built game page (see below)
 - Copies `landing/` to `dist/` root
+
+## Leaving a Game
+
+Installed on the Home Screen there is no browser chrome, so a game with no exit
+of its own traps the player — and no game has one of its own. Every built game
+page therefore gets a *‹ Arcade* button in the top-left corner, which asks for
+confirmation and then returns to `/`.
+
+`landing/arcade/home-button.js` is the whole implementation, served at
+`/arcade/home-button.js` and shared by every game. `scripts/build-all.js`
+injects the script tag into each `dist/<game>/**/*.html` after the game builds,
+so **a new game needs no back-button code of its own** — and Vite never sees
+the absolute path, which it would otherwise fail to resolve.
+
+Because the injected tag is a fixed one-liner, editing the button's code never
+requires rebuilding a game; only changing the tag itself does, and editing
+`build-all.js` already rebuilds everything.
+
+A game whose own UI already holds that corner moves the button with one line in
+its `index.html`:
+
+```html
+<meta name="arcade-home-button" content="bottom-left" />
+```
+
+`top-left` (default), `top-right`, `bottom-left`, `bottom-right`, or `off` for a
+game that grows a real arcade exit of its own. The rule used so far: move it to
+a corner the game leaves free, and where a game holds all four (robot-rally,
+treasure-hunt-island) leave it at the default and accept that it sits over a
+score pill. Prefer covering a read-only panel over a control — bottom-left is
+a joystick in robot-rally and touch controls in treasure-hunt-island.
+
+The button only draws itself in an installed app (`display-mode: standalone`
+and friends, or `navigator.standalone` on iOS). In an ordinary tab Safari's own
+back button already does the job, so a second one would just cover the game. It
+renders in a shadow root — like `arcade.js` — so no game's CSS can reach it, and
+it sits inside `env(safe-area-inset-*)` to clear the notch.
 
 ## Deployment
 

--- a/games/air-hockey/index.html
+++ b/games/air-hockey/index.html
@@ -7,6 +7,9 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <meta name="theme-color" content="#04060f" />
+    <!-- The HUD spans the top edge — "‹ Menu" at the left, mute at the right —
+         so the arcade's back button (injected at build time) drops below it. -->
+    <meta name="arcade-home-button" content="bottom-left" />
     <title>Air Hockey</title>
     <link
       rel="icon"

--- a/games/comet-dash/index.html
+++ b/games/comet-dash/index.html
@@ -6,6 +6,9 @@
   <meta name="theme-color" content="#060213" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='20' cy='12' r='7' fill='%2337f2ff'/%3E%3Cpath d='M2 30 L14 16 L18 20 Z' fill='%23ff3fd8'/%3E%3C/svg%3E" />
   <title>Comet Dash</title>
+  <!-- #hud holds the top-left corner and #mute the top-right, so the arcade's
+       back button (injected at build time) takes a free one. -->
+  <meta name="arcade-home-button" content="bottom-left" />
   <style>
     :root {
       --cyan: #37f2ff;

--- a/games/grand-hotel-tycoon/index.html
+++ b/games/grand-hotel-tycoon/index.html
@@ -6,6 +6,9 @@
   <meta name="theme-color" content="#7FD4F5" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%237FD4F5'/%3E%3Crect x='7' y='9' width='18' height='16' rx='2' fill='%23FFF3E0'/%3E%3Cpath d='M5 10 L16 4 L27 10 Z' fill='%23E8734A'/%3E%3Crect x='10' y='13' width='4' height='4' fill='%23FFC94A'/%3E%3Crect x='18' y='13' width='4' height='4' fill='%23FFC94A'/%3E%3C/svg%3E" />
   <title>Grand Hotel Tycoon</title>
+  <!-- The money panel holds the top-left corner and the minimap the bottom-left,
+       so the arcade's back button (injected at build time) goes top-right. -->
+  <meta name="arcade-home-button" content="top-right" />
   <style>
     :root {
       --sky: #7fd4f5;

--- a/games/skee-ball/index.html
+++ b/games/skee-ball/index.html
@@ -6,6 +6,9 @@
   <meta name="theme-color" content="#0a0614" />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='13' r='10' fill='none' stroke='%23ffd54a' stroke-width='3'/%3E%3Ccircle cx='16' cy='13' r='3.5' fill='%23ff3fd8'/%3E%3Crect x='6' y='25' width='20' height='4' rx='2' fill='%2337f2ff'/%3E%3C/svg%3E" />
   <title>Skee-Ball</title>
+  <!-- Score, pips and mute already hold three corners, so the arcade's back
+       button (injected at build time) takes the free one. -->
+  <meta name="arcade-home-button" content="bottom-left" />
   <style>
     :root {
       --gold: #ffd54a;

--- a/landing/arcade/home-button.js
+++ b/landing/arcade/home-button.js
@@ -1,0 +1,250 @@
+// The way out of a game, served at /arcade/home-button.js.
+//
+// `scripts/build-all.js` injects a tag for this file into every game's HTML at
+// build time, so games need no exit code of their own — and a new game gets one
+// for free. Because the tag is a fixed one-liner pointing at the site root,
+// editing this file never requires rebuilding any game.
+//
+// It only draws anything when the arcade is running as an installed app
+// (Add to Home Screen on iPad/iPhone, or an installed PWA elsewhere). That is
+// the case where there is no browser chrome and therefore no other way back to
+// the menu — in a normal tab Safari's own back button already does the job, and
+// a second one would just cover up the game.
+//
+// Deliberately a *classic* script, not a module, for the same reason as
+// arcade.js: Vite resolves absolute `<script type="module" src>` paths at build
+// time and fails on a file that only exists at the site root, while a plain
+// script tag passes through untouched. It also renders inside a shadow root so
+// that no game's CSS can reach it and it cannot reach into any game.
+
+(function () {
+  'use strict';
+
+  // Installed-app detection. iOS Safari predates display-mode and reports
+  // `navigator.standalone` instead; the extra display modes cover installed
+  // apps on Android and desktop.
+  function isInstalledApp() {
+    if (window.navigator.standalone === true) return true;
+    return ['standalone', 'fullscreen', 'minimal-ui', 'window-controls-overlay'].some(
+      (mode) => window.matchMedia(`(display-mode: ${mode})`).matches
+    );
+  }
+
+  // The landing page is its own way home, and a game served from its own dev
+  // server has no arcade to go back to.
+  function isGamePage() {
+    return window.location.pathname.replace(/\/+$/, '') !== '';
+  }
+
+  if (!isInstalledApp() || !isGamePage()) return;
+
+  // Top-left is where a back button belongs, but a game that already has its
+  // own chrome there can move this one out of the way with
+  //   <meta name="arcade-home-button" content="top-right">
+  // in its index.html. `off` suppresses it altogether, for a game that grows a
+  // real arcade exit of its own.
+  const CORNERS = {
+    'top-left': 'top: max(env(safe-area-inset-top), 10px); left: max(env(safe-area-inset-left), 10px);',
+    'top-right': 'top: max(env(safe-area-inset-top), 10px); right: max(env(safe-area-inset-right), 10px);',
+    'bottom-left': 'bottom: max(env(safe-area-inset-bottom), 10px); left: max(env(safe-area-inset-left), 10px);',
+    'bottom-right': 'bottom: max(env(safe-area-inset-bottom), 10px); right: max(env(safe-area-inset-right), 10px);',
+  };
+
+  const requested = (
+    document.querySelector('meta[name="arcade-home-button"]')?.content || ''
+  ).trim().toLowerCase();
+
+  if (requested === 'off') return;
+
+  // Own-property check, so a typo like "constructor" falls back rather than
+  // reaching an inherited property — and the layout below follows the corner
+  // actually used, not what was asked for.
+  const placement = Object.prototype.hasOwnProperty.call(CORNERS, requested) ? requested : 'top-left';
+  const corner = CORNERS[placement];
+  // A card opening from the bottom of the screen has to grow upwards.
+  const fromBottom = placement.startsWith('bottom');
+  const alignRight = placement.endsWith('right');
+
+  const STYLES = `
+    :host {
+      position: fixed;
+      ${corner}
+      z-index: 2147483000;
+      /* Lays the confirm card out under the button — or above it, and edge-
+         aligned, in whichever corner the game asked for. */
+      display: flex;
+      flex-direction: ${fromBottom ? 'column-reverse' : 'column'};
+      align-items: ${alignRight ? 'flex-end' : 'flex-start'};
+      gap: 8px;
+      /* The host spans more than the button once the confirm card opens, so it
+         stays transparent to taps and only the controls themselves catch them. */
+      pointer-events: none;
+      font-family: ui-rounded, system-ui, -apple-system, 'Segoe UI', sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    button {
+      pointer-events: auto;
+      font: inherit;
+      cursor: pointer;
+      border: 0;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: manipulation;
+    }
+
+    .home {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      padding: 8px 13px 8px 10px;
+      /* Comfortably past the 44px iOS touch target once the padding is added,
+         without the visual weight of a 44px-tall button over gameplay. */
+      min-height: 36px;
+      border-radius: 999px;
+      color: #fff;
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      background: rgba(24, 16, 44, 0.62);
+      -webkit-backdrop-filter: blur(10px);
+      backdrop-filter: blur(10px);
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.28), inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+      /* Held back from full strength so it reads as chrome, not as part of the
+         game — but stays plainly visible to a kid looking for the way out. */
+      opacity: 0.82;
+      transition: opacity 0.15s ease, transform 0.15s ease;
+    }
+
+    .home:hover { opacity: 1; }
+    .home:active { transform: scale(0.95); opacity: 1; }
+    .home:focus-visible { outline: 3px solid #a78bfa; outline-offset: 2px; opacity: 1; }
+    .home svg { flex: none; }
+
+    .card {
+      pointer-events: auto;
+      width: max-content;
+      max-width: min(78vw, 300px);
+      padding: 14px;
+      border-radius: 16px;
+      color: #fff;
+      background: rgba(24, 16, 44, 0.94);
+      -webkit-backdrop-filter: blur(14px);
+      backdrop-filter: blur(14px);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+    }
+
+    .card p {
+      margin: 0 0 12px;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+
+    .actions { display: flex; gap: 8px; }
+
+    .actions button {
+      flex: 1;
+      min-height: 40px;
+      padding: 0 14px;
+      border-radius: 11px;
+      font-size: 14px;
+      font-weight: 600;
+    }
+
+    .leave { color: #fff; background: #7c3aed; }
+    .leave:active { background: #6d28d9; }
+    .stay { color: #fff; background: rgba(255, 255, 255, 0.14); }
+    .stay:active { background: rgba(255, 255, 255, 0.22); }
+    .actions button:focus-visible { outline: 3px solid #a78bfa; outline-offset: 2px; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .home { transition: none; }
+    }
+  `;
+
+  const host = document.createElement('div');
+  // A game's own stylesheet can still reach the host element itself, so the
+  // few properties that decide where it sits are repeated inline.
+  host.style.cssText = `position:fixed;z-index:2147483000;pointer-events:none;${corner}`;
+  const root = host.attachShadow({ mode: 'open' });
+
+  const style = document.createElement('style');
+  style.textContent = STYLES;
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'home';
+  button.setAttribute('aria-label', 'Leave this game and go back to the arcade');
+  button.innerHTML =
+    '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M15 5 8 12l7 7"/></svg><span>Arcade</span>';
+
+  root.append(style, button);
+
+  // Leaving is one tap away from the middle of a game and nothing here is
+  // saved, so it asks first. The card is built on demand and thrown away, which
+  // keeps the idle state to a single button.
+  let card = null;
+
+  function closeCard() {
+    if (!card) return;
+    card.remove();
+    card = null;
+    button.setAttribute('aria-expanded', 'false');
+  }
+
+  function leave() {
+    // Absolute, so it works the same from /phase-10/ as from a game's nested
+    // page, and stays inside the installed app's scope.
+    window.location.href = '/';
+  }
+
+  function openCard() {
+    if (card) return;
+    card = document.createElement('div');
+    card.className = 'card';
+    card.setAttribute('role', 'dialog');
+    card.setAttribute('aria-label', 'Leave this game?');
+    card.innerHTML =
+      '<p>Leave this game and go back to the arcade? This game will start over.</p>' +
+      '<div class="actions">' +
+      '<button type="button" class="leave">Leave</button>' +
+      '<button type="button" class="stay">Keep playing</button>' +
+      '</div>';
+    card.querySelector('.leave').addEventListener('click', leave);
+    card.querySelector('.stay').addEventListener('click', () => {
+      closeCard();
+      button.focus();
+    });
+    root.appendChild(card);
+    button.setAttribute('aria-expanded', 'true');
+    card.querySelector('.leave').focus();
+  }
+
+  button.setAttribute('aria-expanded', 'false');
+  button.addEventListener('click', () => (card ? closeCard() : openCard()));
+
+  // Tapping the game behind the card dismisses it. Capture, because a game that
+  // stops propagation on its own canvas would otherwise leave it stuck open.
+  document.addEventListener(
+    'pointerdown',
+    (event) => {
+      if (card && !event.composedPath().includes(host)) closeCard();
+    },
+    true
+  );
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && card) {
+      closeCard();
+      button.focus();
+    }
+  });
+
+  function mount() {
+    document.body.appendChild(host);
+  }
+
+  if (document.body) mount();
+  else document.addEventListener('DOMContentLoaded', mount);
+})();

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -115,6 +115,35 @@ function formatBytes(bytes) {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+// Installed on the Home Screen there is no browser chrome, so a game with no
+// exit of its own traps the player — and no game has one. Rather than ask 23
+// games to each grow a back button, every built page gets a tag for the shared
+// one at /arcade/home-button.js, which decides for itself whether to draw
+// anything (it only does in an installed app).
+//
+// Injecting here rather than in each game's source means a new game is covered
+// the day it is added, and a game built by Vite cannot resolve the absolute
+// path away. The tag is a fixed one-liner, so changing the button's code never
+// needs a game rebuild — only this line changing does, and editing this file
+// already rebuilds everything.
+const HOME_BUTTON_SRC = '/arcade/home-button.js';
+const HOME_BUTTON_TAG = `<script defer src="${HOME_BUTTON_SRC}"></script>`;
+
+function injectHomeButton(distDir) {
+  for (const file of collectFiles(distDir)) {
+    if (!file.endsWith('.html')) continue;
+    const html = fs.readFileSync(file, 'utf8');
+    if (html.includes(HOME_BUTTON_SRC)) continue;
+    // Last </body> — a game's HTML may well contain the string earlier, inside
+    // a script or a template.
+    const at = html.lastIndexOf('</body>');
+    fs.writeFileSync(
+      file,
+      at === -1 ? html + `\n${HOME_BUTTON_TAG}\n` : html.slice(0, at) + `${HOME_BUTTON_TAG}\n` + html.slice(at)
+    );
+  }
+}
+
 // Writes dist/sw.js from scripts/sw-template.js, injecting the list of every
 // built file plus a version hash derived from their contents.
 function buildServiceWorker() {
@@ -278,6 +307,8 @@ for (const game of games) {
     copyRecursive(buildOutput, gameDist);
     console.log(`✅ ${game} → dist/${game}/`);
   }
+
+  injectHomeButton(gameDist);
 
   manifest.entries[game] = { sourceHash, depsHash };
   builtCount++;


### PR DESCRIPTION
Installed on the Home Screen there is no browser chrome, so a game with
no exit of its own trapped the player — and no game had one. The "Back
to Menu" buttons that exist today all navigate within their own game.

Adds landing/arcade/home-button.js, served at /arcade/home-button.js and
shared by every game, and injects the script tag into each built game
page from build-all.js. Injecting at build time means a new game is
covered the day it is added, and Vite never sees the absolute path it
would fail to resolve. Since the tag is a fixed one-liner, editing the
button never forces a game rebuild.

It only draws itself in an installed app, via navigator.standalone on
iOS or display-mode elsewhere; in an ordinary tab Safari's own back
button already does the job. It renders in a shadow root, like
arcade.js, and sits inside env(safe-area-inset-*).

Leaving asks for confirmation first, since nothing here is saved.

Four games already own the top-left corner, so they move the button to
a corner they leave free with a meta tag. Where a game holds all four
(robot-rally, treasure-hunt-island) it stays at the default rather than
cover a joystick or touch controls.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GUpV1c5PxGdYBXdnsPnChZ